### PR TITLE
Filter timeline based on display and task name

### DIFF
--- a/DevOps.Status/Pages/SearchDoc.cshtml
+++ b/DevOps.Status/Pages/SearchDoc.cshtml
@@ -75,6 +75,14 @@
             <td class="font-weight-bold">jobName:"Windows CoreClr"</td>
             <td>Filter to issues on jobs whose name which contain the specified string</td>
         </tr>
+        <tr>
+            <td class="font-weight-bold">displayName:Installer</td>
+            <td>Filter to issues on tasks whose display name contains the specified string</td>
+        </tr>
+        <tr>
+            <td class="font-weight-bold">taskName:CmdLine</td>
+            <td>Filter to issues on tasks whose task name contains the specified string</td>
+        </tr>
     </tbody>
 </table>
 
@@ -177,7 +185,6 @@
         </tr>
     </tbody>
 </table>
-
 
 <h1 class="mt-2"><a id="date-query" href="#date-query" class="text-reset">Date Queries</a></h1>
 

--- a/DevOps.Util.DotNet/DotNetConstants.cs
+++ b/DevOps.Util.DotNet/DotNetConstants.cs
@@ -8,7 +8,7 @@ namespace DevOps.Util.DotNet
     {
         public const string ConfigurationSqlConnectionString = "RUNFO_CONNECTION_STRING";
 #if DEBUG
-        //public const string ConfigurationSqlConnectionString = "RUNFO_CONNECTION_STRING_DEV";
+        // public const string ConfigurationSqlConnectionString = "RUNFO_CONNECTION_STRING_DEV";
 #endif
         public const string ConfigurationAppAzureToken = "RUNFO_AZURE_TOKEN";
         public const string ConfigurationGitHubAppId = "GitHubAppId";

--- a/DevOps.Util.DotNet/Triage/Migrations/20201105072102_TimelineIssuesTaskName.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201105072102_TimelineIssuesTaskName.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20201105072102_TimelineIssuesTaskName")]
+    partial class TimelineIssuesTaskName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DevOps.Util.DotNet/Triage/Migrations/20201105072102_TimelineIssuesTaskName.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201105072102_TimelineIssuesTaskName.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class TimelineIssuesTaskName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TaskName",
+                table: "ModelTimelineIssues",
+                type: "nvarchar(100)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TaskName",
+                table: "ModelTimelineIssues");
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Model.cs
+++ b/DevOps.Util.DotNet/Triage/Model.cs
@@ -115,10 +115,8 @@ namespace DevOps.Util.DotNet.Triage
 
     public static class ModelConstants
     {
-        public const string GitHubRepositoryTypeName = "nvarchar(100)";
-
         public const string GitHubOrganizationTypeName = "nvarchar(100)";
-
+        public const string GitHubRepositoryTypeName = "nvarchar(100)";
         public const string BuildDefinitionNameTypeName = "nvarchar(100)";
     }
 
@@ -265,6 +263,9 @@ namespace DevOps.Util.DotNet.Triage
         public string JobName { get; set; }
 
         public string RecordName { get; set; }
+
+        [Column(TypeName = "nvarchar(100)")]
+        public string TaskName { get; set; }
 
         public string RecordId { get; set; }
 

--- a/DevOps.Util.DotNet/Triage/SearchTimelinesRequest.cs
+++ b/DevOps.Util.DotNet/Triage/SearchTimelinesRequest.cs
@@ -21,6 +21,8 @@ namespace DevOps.Util.DotNet.Triage
 
         public string? Text { get; set; }
         public string? JobName { get; set; }
+        public string? DisplayName { get; set; }
+        public string? TaskName { get; set; }
         public IssueType? Type { get; set; }
 
         public IQueryable<ModelTimelineIssue> Filter(IQueryable<ModelTimelineIssue> query)
@@ -33,6 +35,16 @@ namespace DevOps.Util.DotNet.Triage
             if (!string.IsNullOrEmpty(JobName))
             {
                 query = query.Where(x => x.JobName.Contains(JobName));
+            }
+
+            if (!string.IsNullOrEmpty(TaskName))
+            {
+                query = query.Where(x => x.TaskName.Contains(TaskName));
+            }
+
+            if (!string.IsNullOrEmpty(DisplayName))
+            {
+                query = query.Where(x => x.RecordName.Contains(DisplayName));
             }
 
             // Keep this in sync with logic in SearchTestsRequest
@@ -73,6 +85,16 @@ namespace DevOps.Util.DotNet.Triage
                 Append($"jobName:\"{JobName}\"");
             }
 
+            if (!string.IsNullOrEmpty(DisplayName))
+            {
+                Append($"displayName:\"{DisplayName}\"");
+            }
+
+            if (!string.IsNullOrEmpty(TaskName))
+            {
+                Append($"taskName:\"{TaskName}\"");
+            }
+
             if (Type is { } type)
             {
                 Append($"type:{type}");
@@ -108,6 +130,12 @@ namespace DevOps.Util.DotNet.Triage
                         break;
                     case "jobname":
                         JobName = tuple.Value.Trim('"');
+                        break;
+                    case "displayname":
+                        DisplayName = tuple.Value.Trim('"');
+                        break;
+                    case "taskname":
+                        TaskName = tuple.Value.Trim('"');
                         break;
                     case "type":
                         Type = tuple.Value.ToLower() switch

--- a/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
+++ b/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
@@ -223,6 +223,7 @@ namespace DevOps.Util.DotNet.Triage
                         Attempt = attempt,
                         JobName = job.Name,
                         RecordName = record.Name,
+                        TaskName = record.Task?.Name ?? "",
                         RecordId = record.Id,
                         Message = issue.Message,
                         ModelBuild = modelBuild,

--- a/DevOps.Util.UnitTests/SearchRequestContentTests.cs
+++ b/DevOps.Util.UnitTests/SearchRequestContentTests.cs
@@ -42,6 +42,9 @@ namespace DevOps.Util.UnitTests
         [InlineData("text:\"error\"", "text:\"error\"")]
         [InlineData("text:\"error and space\"", "text:\"error and space\"")]
         [InlineData("text:\"error and space\"   ", "text:\"error and space\"")]
+        [InlineData("displayName:Installer   ", "displayName:\"Installer\"")]
+        [InlineData("taskName:Installer   ", "taskName:\"Installer\"")]
+        [InlineData("taskName:Task displayName:Display", "displayName:\"Display\" taskName:\"Task\"")]
         [InlineData("error", "text:\"error\"")]
         [InlineData("text:error", "text:\"error\"")]
         public void TimelineRoundTrip(string toParse, string userQuery)

--- a/DevOps.Util/RestApiDataTypes.cs
+++ b/DevOps.Util/RestApiDataTypes.cs
@@ -439,7 +439,7 @@ namespace DevOps.Util
         public TaskResult Result { get; set; }
         public string ResultCode { get; set; }
         public string StartTime { get; set; }
-        public TaskReference Task { get; set; }
+        public TaskReference? Task { get; set; }
         public string Url { get; set; }
         public int WarningCount { get; set; }
         public string WorkerName { get; set; }

--- a/scratch/Queries/SQLQuery2.sql
+++ b/scratch/Queries/SQLQuery2.sql
@@ -47,6 +47,44 @@
   FROM ModelBuilds AS [m0]
   WHERE (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-10-25')  AND DefinitionName = 'roslyn-ci'
 
+  SELECT TOP 40 JobName,RecordName,TaskName
+  FROM ModelTimelineIssues
+  ORDER BY Id DESC
+
+
+  -- Investigating the performance of the TaskName queries
+
+  -- TaskName via =
+  -- Two Index Seek and a Key Lookup 
+  SELECT [m].[JobName], [m].[RecordName], [m].[TaskName], [m].[Message]
+  FROM [ModelTimelineIssues] AS [m]
+  LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+  WHERE ((([m0].[DefinitionName] = 'runtime') AND (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-11-02')) AND ((CHARINDEX('CmdLine', [m].[TaskName]) > 0))) AND CONTAINS([m].[Message], 'error')
+
+  -- TaskName via CHARINDEX
+  SELECT [m].[JobName], [m].[RecordName], [m].[TaskName], [m].[Message]
+  FROM [ModelTimelineIssues] AS [m]
+  LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+  WHERE ((([m0].[DefinitionName] = 'runtime') AND (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-11-02')) AND ('CmdLine' = [m].[TaskName])) AND CONTAINS([m].[Message], 'error')
+
+
+  SELECT COUNT(*)
+  FROM ModelTimelineIssues
+
+-- TimelineIssues page using index
+
+SELECT [m1].[BuildNumber], [t].[Message], [t].[JobName], [t].[IssueType], [t].[Attempt]
+FROM (
+  SELECT [m].[Id], [m].[Attempt], [m].[IssueType], [m].[JobName], [m].[Message], [m].[ModelBuildAttemptId], [m].[ModelBuildId], [m].[RecordId], [m].[RecordName], [m].[TaskName], [m0].[BuildNumber]
+  FROM [ModelTimelineIssues] AS [m]
+  LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+  WHERE (([m0].[DefinitionId] = 686 AND (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-11-02')) AND (('Installer' = N'') OR (CHARINDEX('Installer', [m].[JobName]) > 0)))
+  ORDER BY [m0].[BuildNumber] DESC
+  OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
+) AS [t]
+LEFT JOIN [ModelBuilds] AS [m1] ON [t].[ModelBuildId] = [m1].[Id]
+ORDER BY [t].[BuildNumber] DESC
+
 --  CREATE INDEX IX_Manual_ModelBuilds_StartTime
 -- DROP INDEX IX_Manual_ModelBuilds_StartTime ON ModelBuilds
 -- CREATE INDEX IX_Manual_ModelBuildDefinitions_DefinitionId ON ModelBuildDefinitions (DefinitionId)

--- a/scratch/Queries/Scratch2.sql
+++ b/scratch/Queries/Scratch2.sql
@@ -1,1 +1,2 @@
-﻿S	
+﻿SELECT TOP (10) *
+FROM ModelTimelineIssues

--- a/scratch/scratch.csproj
+++ b/scratch/scratch.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>67c4a872-5dd7-422a-acad-fdbe907ace33</UserSecretsId>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds two new filter options for timeline issues:

- displayName: this is the display name for a task where the timeline
issue occurs
- taskName: this is the actual name of the task where the timeline issue
occurs

Couple of notes about this change:

1. The "taskName" field will only be populated going forward but
"displayName" has been in the DB from the beginning so it should be
usable immediately.
1. Profiling timeline issues today I found I could dramatically increase
their performance by using index included columns. Filed #79 to track
doing that work.

closes #70

