### PR TITLE
Remove DateTimeOffset usage

### DIFF
--- a/DevOps.Util.DotNet/Triage/RequestValues.cs
+++ b/DevOps.Util.DotNet/Triage/RequestValues.cs
@@ -110,11 +110,11 @@ namespace DevOps.Util.DotNet.Triage
 
     public readonly struct DateRequestValue : IRequestValue<RelationalKind>
     {
-        public DateTimeOffset DateTime { get; }
+        public DateTime DateTime { get; }
         public RelationalKind Kind { get; }
         public int? DayQuery { get; }
 
-        public DateRequestValue(DateTimeOffset dateTime, RelationalKind kind)
+        public DateRequestValue(DateTime dateTime, RelationalKind kind)
         {
             DateTime = dateTime;
             Kind = kind;
@@ -123,7 +123,7 @@ namespace DevOps.Util.DotNet.Triage
 
         public DateRequestValue(int dayQuery, RelationalKind kind = RelationalKind.GreaterThan)
         {
-            DateTime = System.DateTimeOffset.UtcNow - TimeSpan.FromDays(dayQuery);
+            DateTime = System.DateTime.UtcNow - TimeSpan.FromDays(dayQuery);
             Kind = kind;
             DayQuery = dayQuery;
         }
@@ -157,7 +157,7 @@ namespace DevOps.Util.DotNet.Triage
 
             var dt = System.DateTime.ParseExact(data, "yyyy-M-d", CultureInfo.InvariantCulture);
             dt = System.DateTime.SpecifyKind(dt, DateTimeKind.Local);
-            return new DateRequestValue(new DateTimeOffset(dt.ToUniversalTime()), kind);
+            return new DateRequestValue(dt.ToUniversalTime(), kind);
         }
     }
 

--- a/scratch/Queries/Scratch2.sql
+++ b/scratch/Queries/Scratch2.sql
@@ -1,2 +1,37 @@
 ﻿SELECT TOP (10) *
 FROM ModelTimelineIssues
+
+
+SELECT [m].[JobName], [m].[RecordName], [m].[TaskName], [m].[Message]
+FROM [ModelTimelineIssues] AS [m]
+LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+WHERE ((([m0].[DefinitionName] = 'runtime') AND (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-11-02')) AND ((CHARINDEX('CmdLine', [m].[TaskName]) > 0))) AND CONTAINS([m].[Message], 'error')
+
+SELECT TOP(10) [m0].[BuildNumber], [m].[JobName], [m].[RecordName], [m].[TaskName], [m].[Message]
+FROM [ModelTimelineIssues] AS [m]
+LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+WHERE (([m0].[DefinitionName] = 'runtime') AND (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-11-02'))
+
+SELECT TOP(10) [m].[JobName], [m].[RecordName], [m].[TaskName], [m].[Message]
+FROM [ModelTimelineIssues] AS [m]
+LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+WHERE (([m0].[DefinitionName] = 'runtime') AND ([m0].[StartTime] > '2020-11-02'))
+
+SELECT [m].[JobName], [m].[RecordName], [m].[TaskName], [m].[Message]
+FROM [ModelTimelineIssues] AS [m]
+LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+WHERE (([m0].[DefinitionName] = 'runtime') AND (CAST([m0].[StartTime] AS datetimeoffset) >= '2020-11-02')) 
+ORDER BY [m0].[BuildNumber] DESC
+OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
+
+SELECT [m1].[BuildNumber], [t].[Message], [t].[JobName], [t].[IssueType], [t].[Attempt]
+FROM (
+  SELECT [m].[Id], [m].[Attempt], [m].[IssueType], [m].[JobName], [m].[Message], [m].[ModelBuildAttemptId], [m].[ModelBuildId], [m].[RecordId], [m].[RecordName], [m].[TaskName], [m0].[BuildNumber]
+  FROM [ModelTimelineIssues] AS [m]
+  LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+  WHERE ([m0].[DefinitionId] = 686) AND ([m0].[StartTime] >= '2020-11-05')
+  ORDER BY [m0].[BuildNumber] DESC
+  OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
+) AS [t]
+LEFT JOIN [ModelBuilds] AS [m1] ON [t].[ModelBuildId] = [m1].[Id]
+ORDER BY [t].[BuildNumber] DESC


### PR DESCRIPTION
The date type used in the actual column storage is different than the
date time used in the filters. That was introducing extra work in all of
the queries to convert the column type.

True this was an cheap operation but it's totally unnecessary work here.
Using the same date type throughout is simple to do here.