### PR TITLE
Timelines perf issues

### DIFF
--- a/DevOps.Status/Startup.cs
+++ b/DevOps.Status/Startup.cs
@@ -74,6 +74,7 @@ namespace DevOps.Status
                 var connectionString = Configuration[DotNetConstants.ConfigurationSqlConnectionString];
 #if DEBUG
                 options.UseLoggerFactory(LoggerFactory.Create(builder => builder.AddConsole()));
+                options.EnableSensitiveDataLogging();
 #endif
                 options.UseSqlServer(connectionString);
             });

--- a/DevOps.Util.DotNet/Triage/Migrations/20201206050639_ModelTimelineIssuesIncludeColumns.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201206050639_ModelTimelineIssuesIncludeColumns.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20201206050639_ModelTimelineIssuesIncludeColumns")]
+    partial class ModelTimelineIssuesIncludeColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DevOps.Util.DotNet/Triage/Migrations/20201206050639_ModelTimelineIssuesIncludeColumns.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201206050639_ModelTimelineIssuesIncludeColumns.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class ModelTimelineIssuesIncludeColumns : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelTimelineIssues_ModelBuildId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelTimelineIssues_ModelBuildId",
+                table: "ModelTimelineIssues",
+                column: "ModelBuildId")
+                .Annotation("SqlServer:Include", new[] { "JobName", "TaskName", "RecordName", "IssueType", "Attempt", "Message" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelTimelineIssues_ModelBuildId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelTimelineIssues_ModelBuildId",
+                table: "ModelTimelineIssues",
+                column: "ModelBuildId");
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Model.cs
+++ b/DevOps.Util.DotNet/Triage/Model.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using DevOps.Util.DotNet;
 using Microsoft.EntityFrameworkCore;
+using Org.BouncyCastle.Math.EC.Rfc7748;
 
 namespace DevOps.Util.DotNet.Triage
 {
@@ -91,6 +92,10 @@ namespace DevOps.Util.DotNet.Triage
                 .Property(x => x.IssueType)
                 .HasConversion<string>()
                 .HasDefaultValue(IssueType.Warning);
+
+            modelBuilder.Entity<ModelTimelineIssue>()
+                .HasIndex(x => x.ModelBuildId)
+                .IncludeProperties(x => new { x.JobName, x.TaskName, x.RecordName, x.IssueType, x.Attempt, x.Message });
 
             modelBuilder.Entity<ModelTrackingIssue>()
                 .Property(x => x.TrackingKind)

--- a/DevOps.Util.DotNet/Triage/SearchBuildsRequest.cs
+++ b/DevOps.Util.DotNet/Triage/SearchBuildsRequest.cs
@@ -89,8 +89,8 @@ namespace DevOps.Util.DotNet.Triage
             {
                 query = queued.Kind switch
                 {
-                    RelationalKind.GreaterThan => query.Where(convertPredicateFunc(x => x.QueueTime >= queued.DateTime)),
-                    RelationalKind.LessThan => query.Where(convertPredicateFunc(x => x.QueueTime <= queued.DateTime)),
+                    RelationalKind.GreaterThan => query.Where(convertPredicateFunc(x => x.QueueTime >= queued.DateTime.Date)),
+                    RelationalKind.LessThan => query.Where(convertPredicateFunc(x => x.QueueTime <= queued.DateTime.Date)),
                     _ => query
                 };
             }
@@ -99,8 +99,8 @@ namespace DevOps.Util.DotNet.Triage
             {
                 query = started.Kind switch
                 {
-                    RelationalKind.GreaterThan => query.Where(convertPredicateFunc(x => x.StartTime >= started.DateTime)),
-                    RelationalKind.LessThan => query.Where(convertPredicateFunc(x => x.StartTime <= started.DateTime)),
+                    RelationalKind.GreaterThan => query.Where(convertPredicateFunc(x => x.StartTime >= started.DateTime.Date)),
+                    RelationalKind.LessThan => query.Where(convertPredicateFunc(x => x.StartTime <= started.DateTime.Date)),
                     _ => query
                 };
             }
@@ -109,8 +109,8 @@ namespace DevOps.Util.DotNet.Triage
             {
                 query = finished.Kind switch
                 {
-                    RelationalKind.GreaterThan => query.Where(convertPredicateFunc(x => x.FinishTime >= finished.DateTime)),
-                    RelationalKind.LessThan => query.Where(convertPredicateFunc(x => x.FinishTime <= finished.DateTime)),
+                    RelationalKind.GreaterThan => query.Where(convertPredicateFunc(x => x.FinishTime >= finished.DateTime.Date)),
+                    RelationalKind.LessThan => query.Where(convertPredicateFunc(x => x.FinishTime <= finished.DateTime.Date)),
                     _ => query
                 };
             }

--- a/scratch/Program.cs
+++ b/scratch/Program.cs
@@ -55,7 +55,7 @@ namespace Scratch
                 var configuration = ScratchUtil.CreateConfiguration();
                 var connectionString = configuration[DotNetConstants.ConfigurationSqlConnectionString];
                 var message = connectionString.Contains("triage-scratch-dev")
-                    ? "Using sql dev"
+                    ? "Using sql developer"
                     : "Using sql production";
                 Console.WriteLine(message);
                 builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(145).TotalSeconds));
@@ -103,8 +103,13 @@ namespace Scratch
             DevOpsServer = new DevOpsServer(organization, new AuthorizationToken(AuthorizationKind.PersonalAccessToken, azureToken));
 
             var builder = new DbContextOptionsBuilder<TriageContext>();
-            builder.UseSqlServer(configuration[DotNetConstants.ConfigurationSqlConnectionString]);
-            builder.UseLoggerFactory(LoggerFactory.Create(builder => builder.AddConsole()));
+            var connectionString = configuration[DotNetConstants.ConfigurationSqlConnectionString];
+            var message = connectionString.Contains("triage-scratch-dev")
+                ? "Using sql developer"
+                : "Using sql production";
+            builder.UseSqlServer(connectionString);
+
+            // builder.UseLoggerFactory(LoggerFactory.Create(builder => builder.AddConsole()));
             TriageContext = new TriageContext(builder.Options);
             TriageContextUtil = new TriageContextUtil(TriageContext);
 
@@ -139,7 +144,9 @@ namespace Scratch
 
         internal async Task Scratch()
         {
+            await PopulateDb(count: 100, definitionId: 686, includeTests: false, includeTriage: false);
 
+            /*
             var buildInfo = (await DevOpsServer.GetBuildAsync("public", 906787)).GetBuildResultInfo();
             var results = await DotNetQueryUtil.SearchBuildLogsAsync(
                 new[] { buildInfo },
@@ -152,6 +159,7 @@ namespace Scratch
 
             Console.WriteLine(results.Count(x =>  x.IsMatch));
             Console.WriteLine(results.Count);
+            */
 
 /*
 

--- a/scratch/Queries/PerformanceQueries.sql
+++ b/scratch/Queries/PerformanceQueries.sql
@@ -1,0 +1,51 @@
+﻿/*SELECT * FROM ModelTimelineIssues */
+/*SELECT COUNT(*) FROM ModelTimelineIssues*/
+SELECT * FROM ModelTestResults
+
+/* Search for timeline issues by text */
+SELECT [m1].[BuildNumber], [t].[Message], [t].[JobName], [t].[IssueType], [t].[Attempt]
+FROM (
+  SELECT [m].[Id], [m].[Attempt], [m].[IssueType], [m].[JobName], [m].[Message], [m].[ModelBuildAttemptId], [m].[ModelBuildId], [m].[RecordId], [m].[RecordName], [m].[TaskName], [m0].[BuildNumber]
+  FROM [ModelTimelineIssues] AS [m]
+  LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+  WHERE ([m0].[DefinitionId] = 686) AND CONTAINS([m].[Message], '"returned from process"')
+  ORDER BY [m0].[BuildNumber] DESC
+  OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
+) AS [t]
+LEFT JOIN [ModelBuilds] AS [m1] ON [t].[ModelBuildId] = [m1].[Id]
+ORDER BY [t].[BuildNumber] DESC
+
+
+/* Search for timeline issues for a time frame and filter by job name */
+SELECT [m1].[BuildNumber], [t].[Message], [t].[JobName], [t].[IssueType], [t].[Attempt]
+FROM (
+  SELECT [m].[Id], [m].[Attempt], [m].[IssueType], [m].[JobName], [m].[Message], [m].[ModelBuildAttemptId], [m].[ModelBuildId], [m].[RecordId], [m].[RecordName], [m].[TaskName], [m0].[BuildNumber]
+  FROM [ModelTimelineIssues] AS [m]
+  LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+  WHERE (([m0].[StartTime] >= '2020-12-01') AND ([m0].[DefinitionId] = 686)) AND (('CoreClr' = N'') OR (CHARINDEX('CoreClr', [m].[JobName]) > 0))
+  ORDER BY [m0].[BuildNumber] DESC
+  OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
+) AS [t]
+LEFT JOIN [ModelBuilds] AS [m1] ON [t].[ModelBuildId] = [m1].[Id]
+ORDER BY [t].[BuildNumber] DESC
+
+/* Search for timeline issue for a text but getting the count */
+/*Failed executing DbCommand (30,359ms) [Parameters=[@__started_DateTime_0='2020-11-29T06:07:21' (Nullable = true) (DbType = DateTime), @__definitionId_1='686' (Nullable = true), @__text_3='failed' (Size = 4000)], CommandType='Text', CommandTimeout='30'] */
+DECLARE @__started_DateTime_0 DateTime, @__definitionId_1 INT, @__text_3 NVARCHAR(400)
+SET @__started_DateTime_0='2020-11-29T06:07:21'
+SET @__definitionId_1='686'
+SET @__text_3='Failed'
+SELECT COUNT(*)
+FROM [ModelTimelineIssues] AS [m]
+LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+WHERE (([m0].[StartTime] >= @__started_DateTime_0) AND ([m0].[DefinitionId] = @__definitionId_1)) AND CONTAINS([m].[Message], @__text_3)
+
+/*Failed executing DbCommand (30,359ms) [Parameters=[@__started_DateTime_0='2020-11-29T06:07:21' (Nullable = true) (DbType = DateTime), @__definitionId_1='686' (Nullable = true), @__text_3='failed' (Size = 4000)], CommandType='Text', CommandTimeout='30'] */
+DECLARE @__started_DateTime_0 DateTime, @__definitionId_1 INT, @__text_3 NVARCHAR(400)
+SET @__started_DateTime_0='2020-11-29T00:00:00'
+SET @__definitionId_1='686'
+SET @__text_3='Failed'
+SELECT COUNT(*)
+FROM [ModelTimelineIssues] AS [m]
+LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+WHERE (([m0].[StartTime] >= @__started_DateTime_0) AND ([m0].[DefinitionId] = @__definitionId_1)) AND CONTAINS([m].[Message], @__text_3)

--- a/scratch/Queries/TimelineIssues.sql
+++ b/scratch/Queries/TimelineIssues.sql
@@ -1,3 +1,0 @@
-﻿/*SELECT * FROM ModelTimelineIssues */
-/*SELECT COUNT(*) FROM ModelTimelineIssues*/
-SELECT * FROM ModelTestResults


### PR DESCRIPTION
The first part of this change is updating the `ModelBuilds` to
`ModelTimelineIssues` index to have a number of included proerties.
These properties are the core of our predicates when filtering on
issues. Now that they are included properties this _significantly
reduces the number of row reads we must do as the properties are right
there to be scanned.

The second part of the change is to use `.Date` in all of our date range
queries. This _significantly_ increases the quality of some of our
queries, particularly the model timeline issues. The hard part is though
that this only reproduces when executing from EF. When I execute the
exact same queries in SQL I get great performance and it hits the
indexes that I would expect. I cannot figure this out and have ruled out
the obvious answers. For now logging the win and will keep researching
for better answers.