### PR TITLE
Clean up ModelBuild indexes

### DIFF
--- a/DevOps.Util.DotNet/DotNetUtil.cs
+++ b/DevOps.Util.DotNet/DotNetUtil.cs
@@ -26,8 +26,9 @@ namespace DevOps.Util.DotNet
             TestOutcome.Aborted
         };
 
-        // TODO: This should all be moved back to runfo at this point. These libraries should be using the real names
-        // at this point
+        // TODO: move this from being a static list to one that we create at start up time.
+        // Many of the optimizations in SearchBuildRequests depends on the IDs being known. All the indexes
+        // are based on it.
         public static readonly (string BuildName, string Project, int DefinitionId)[] BuildDefinitions = new[]
             {
                 ("runtime", "public", 686),

--- a/DevOps.Util.DotNet/Triage/Migrations/20201207224951_SuggestedModelBuildIndexes.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201207224951_SuggestedModelBuildIndexes.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20201207224951_SuggestedModelBuildIndexes")]
+    partial class SuggestedModelBuildIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DevOps.Util.DotNet/Triage/Migrations/20201207224951_SuggestedModelBuildIndexes.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201207224951_SuggestedModelBuildIndexes.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class SuggestedModelBuildIndexes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionId",
+                table: "ModelBuilds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionName",
+                table: "ModelBuilds");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelBuilds_DefinitionId_StartTime",
+                table: "ModelBuilds",
+                columns: new[] { "DefinitionId", "StartTime" })
+                .Annotation("SqlServer:Include", new[] { "BuildNumber", "BuildResult", "PullRequestNumber", "GitHubRepository" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionId",
+                table: "ModelBuilds",
+                columns: new[] { "StartTime", "DefinitionId" })
+                .Annotation("SqlServer:Include", new[] { "BuildNumber", "BuildResult", "PullRequestNumber", "GitHubRepository" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelBuilds_DefinitionId_StartTime",
+                table: "ModelBuilds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionId",
+                table: "ModelBuilds");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionId",
+                table: "ModelBuilds",
+                columns: new[] { "StartTime", "DefinitionId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionName",
+                table: "ModelBuilds",
+                columns: new[] { "StartTime", "DefinitionName" });
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Model.cs
+++ b/DevOps.Util.DotNet/Triage/Model.cs
@@ -67,10 +67,12 @@ namespace DevOps.Util.DotNet.Triage
                 .HasIndex(x => x.BuildResult);
 
             modelBuilder.Entity<ModelBuild>()
-                .HasIndex(x => new { x.StartTime, x.DefinitionName });
+                .HasIndex(x => new { x.StartTime, x.DefinitionId })
+                .IncludeProperties(x => new { x.BuildNumber, x.BuildResult, x.PullRequestNumber, x.GitHubRepository });
 
             modelBuilder.Entity<ModelBuild>()
-                .HasIndex(x => new { x.StartTime, x.DefinitionId });
+                .HasIndex(x => new { x.DefinitionId, x.StartTime })
+                .IncludeProperties(x => new { x.BuildNumber, x.BuildResult, x.PullRequestNumber, x.GitHubRepository });
 
             modelBuilder.Entity<ModelBuildAttempt>()
                 .HasIndex(x => new { x.Attempt, x.ModelBuildId })


### PR DESCRIPTION
Profiling revealed there were two improvements to be made in the indexs
around `StartTime` and `DefinitionId`

- SQL profiler consistently said that it wanted to sort first based on
  `DefinitionId` then by `StartTime` hence added an index for that.
- Included a number of columns that allowed for actions like sorting to
  occur without having to go back and load in the Build rows.