### PR TITLE
Remove hard coded definition names

### DIFF
--- a/DevOps.Functions/Functions.cs
+++ b/DevOps.Functions/Functions.cs
@@ -351,7 +351,7 @@ namespace DevOps.Functions
                 Server,
                 TriageContextUtil,
                 prKey,
-                DotNetUtil.DefaultAzureProject);
+                DotNetConstants.DefaultAzureProject);
         }
     }
 }

--- a/DevOps.Functions/Startup.cs
+++ b/DevOps.Functions/Startup.cs
@@ -28,7 +28,7 @@ namespace DevOps.Functions
             builder.Services.AddDbContext<TriageContext>(options => options.UseSqlServer(connectionString));
             builder.Services.AddScoped<DevOpsServer>(_ =>
                 new DevOpsServer(
-                    DotNetUtil.AzureOrganization,
+                    DotNetConstants.AzureOrganization,
                     new AuthorizationToken(AuthorizationKind.PersonalAccessToken, azdoToken)));
             builder.Services.AddScoped<GitHubClientFactory>(_ =>
             {

--- a/DevOps.Status/Controllers/HelixController.cs
+++ b/DevOps.Status/Controllers/HelixController.cs
@@ -54,7 +54,7 @@ namespace DevOps.Status.Controllers
 
             var queryUtil = await QueryUtilFactory.CreateDotNetQueryUtilForUserAsync();
             var build = await queryUtil.Server.GetBuildAsync(project, buildNumber);
-            var workItems = await queryUtil.ListHelixWorkItemsAsync(build, DotNetUtil.FailedTestOutcomes);
+            var workItems = await queryUtil.ListHelixWorkItemsAsync(build, DevOpsUtil.FailedTestOutcomes);
             var list = new List<HelixWorkItemRestInfo>();
             foreach (var workItem in workItems)
             {

--- a/DevOps.Status/Pages/View/Build.cshtml.cs
+++ b/DevOps.Status/Pages/View/Build.cshtml.cs
@@ -191,6 +191,6 @@ namespace DevOps.Status.Pages.View
             }
         }
 
-        private static BuildKey GetBuildKey(int buildNumber) => new BuildKey(DotNetUtil.AzureOrganization, DotNetUtil.DefaultAzureProject, buildNumber);
+        private static BuildKey GetBuildKey(int buildNumber) => new BuildKey(DotNetConstants.AzureOrganization, DotNetConstants.DefaultAzureProject, buildNumber);
     }
 }

--- a/DevOps.Status/Pages/View/PullRequest.cshtml.cs
+++ b/DevOps.Status/Pages/View/PullRequest.cshtml.cs
@@ -47,14 +47,14 @@ namespace DevOps.Status.Pages.View
                 return;
             }
 
-            var gitHubClient = await GitHubClientFactory.CreateForAppAsync(DotNetUtil.GitHubOrganization, Repository);
-            PullRequest = await gitHubClient.PullRequest.Get(DotNetUtil.GitHubOrganization, Repository, Number.Value);
+            var gitHubClient = await GitHubClientFactory.CreateForAppAsync(DotNetConstants.GitHubOrganization, Repository);
+            PullRequest = await gitHubClient.PullRequest.Get(DotNetConstants.GitHubOrganization, Repository, Number.Value);
 
             var builds = await TriageContext
                 .ModelBuilds
                 .Include(x => x.ModelBuildDefinition)
                 .Where(x =>
-                    x.GitHubOrganization == DotNetUtil.GitHubOrganization &&
+                    x.GitHubOrganization == DotNetConstants.GitHubOrganization &&
                     x.GitHubRepository == Repository &&
                     x.PullRequestNumber == Number)
                 .OrderByDescending(x => x.BuildNumber)

--- a/DevOps.Status/Startup.cs
+++ b/DevOps.Status/Startup.cs
@@ -63,7 +63,7 @@ namespace DevOps.Status
             services.AddScoped<BlobStorageUtil>(_ =>
             {
                 return new BlobStorageUtil(
-                    DotNetUtil.AzureOrganization,
+                    DotNetConstants.AzureOrganization,
                     Configuration[DotNetConstants.ConfigurationAzureBlobConnectionString]);
             });
 

--- a/DevOps.Status/Util/DotNetQueryUtilFactory.cs
+++ b/DevOps.Status/Util/DotNetQueryUtilFactory.cs
@@ -27,17 +27,17 @@ namespace DevOps.Status.Util
         {
             var accessToken = await HttpContextAccessor.HttpContext.GetTokenAsync(VisualStudioAuthenticationDefaults.AuthenticationScheme, "access_token");
             var token = new AuthorizationToken(AuthorizationKind.BearerToken, accessToken);
-            return new DevOpsServer(DotNetUtil.AzureOrganization, token);
+            return new DevOpsServer(DotNetConstants.AzureOrganization, token);
         }
 
         public DevOpsServer CreateDevOpsServerForApp()
         {
             var azdoToken = Configuration[DotNetConstants.ConfigurationAppAzureToken];
             var token = new AuthorizationToken(AuthorizationKind.PersonalAccessToken, azdoToken);
-            return new DevOpsServer(DotNetUtil.AzureOrganization, token);
+            return new DevOpsServer(DotNetConstants.AzureOrganization, token);
         }
 
-        public DevOpsServer CreateDevOpsServerForAnonymous() => new DevOpsServer(DotNetUtil.AzureOrganization);
+        public DevOpsServer CreateDevOpsServerForAnonymous() => new DevOpsServer(DotNetConstants.AzureOrganization);
 
         public async Task<DotNetQueryUtil> CreateDotNetQueryUtilForUserAsync() => CreateForServer(await CreateDevOpsServerForUserAsync());
 

--- a/DevOps.Util.DotNet/BlobStorageUtil.cs
+++ b/DevOps.Util.DotNet/BlobStorageUtil.cs
@@ -131,7 +131,7 @@ namespace DevOps.Util.DotNet
                 return;
             }
 
-            if (outcomes is null || outcomes.Any(x => !DotNetUtil.FailedTestOutcomes.Contains(x)))
+            if (outcomes is null || outcomes.Any(x => !DevOpsUtil.FailedTestOutcomes.Contains(x)))
             {
                 // Only store failed outcems
                 return;

--- a/DevOps.Util.DotNet/DotNetConstants.cs
+++ b/DevOps.Util.DotNet/DotNetConstants.cs
@@ -18,5 +18,10 @@ namespace DevOps.Util.DotNet
         public const string ConfigurationVsoClientId = "VsoClientId";
         public const string ConfigurationVsoClientSecret = "VsoClientSecret";
         public const string ConfigurationAzureBlobConnectionString = "AzureWebJobsStorage";
+
+        public static string GitHubOrganization => "dotnet";
+        public static string AzureOrganization => "dnceng";
+        public static string DefaultAzureProject => "public";
+
     }
 }

--- a/DevOps.Util.DotNet/DotNetQueryUtil.cs
+++ b/DevOps.Util.DotNet/DotNetQueryUtil.cs
@@ -402,7 +402,7 @@ namespace DevOps.Util.DotNet
         public Task<List<Build>> ListBuildsAsync(
             int count = 50,
             string? project = null,
-            string? definition = null,
+            int? definitionId = null,
             string? repositoryName = null,
             string? branch = null,
             bool includePullRequests = false,
@@ -412,18 +412,7 @@ namespace DevOps.Util.DotNet
             string? repositoryId = null;
             if (repositoryName is object)
             {
-                repositoryId = $"{DotNetUtil.GitHubOrganization}/{repositoryName}";
-            }
-
-            int[]? definitions = null;
-            if (definition is object)
-            {
-                if (!DotNetUtil.TryGetDefinitionId(definition, out _, out var definitionId))
-                {
-                    throw new Exception($"Invalid definition name {definition}");
-                }
-
-                definitions = new[] { definitionId };
+                repositoryId = $"{DotNetConstants.GitHubOrganization}/{repositoryName}";
             }
 
             DateTimeOffset? beforeDateTimeOffset = null;
@@ -438,10 +427,12 @@ namespace DevOps.Util.DotNet
                 afterDateTimeOffset = DateTimeOffset.Parse(after);
             }
 
+            var definitionIds = definitionId is { } id ? new[] { id } : Array.Empty<int>();
+
             return ListBuildsAsync(
                 count: count,
                 project: project,
-                definitions: definitions,
+                definitions: definitionIds,
                 repositoryId: repositoryId,
                 branch: branch,
                 includePullRequests: includePullRequests,
@@ -459,7 +450,7 @@ namespace DevOps.Util.DotNet
             DateTimeOffset? before = null,
             DateTimeOffset? after = null)
         {
-            project ??= DotNetUtil.DefaultAzureProject;
+            project ??= DotNetConstants.DefaultAzureProject;
 
             // When doing before / after comparisons always use QueueTime. The StartTime parameter
             // in REST refers to when the latest build attempt started, not the original. Using that

--- a/DevOps.Util.DotNet/Extensions.cs
+++ b/DevOps.Util.DotNet/Extensions.cs
@@ -82,7 +82,7 @@ namespace DevOps.Util.DotNet
                         }
                     }
 
-                    bool IsFailedOutcome(string outcome) => DotNetUtil.FailedTestOutcomes.Any(x => comparer.Equals(x.ToString(), outcome));
+                    bool IsFailedOutcome(string outcome) => DevOpsUtil.FailedTestOutcomes.Any(x => comparer.Equals(x.ToString(), outcome));
                 }
             }
 

--- a/DevOps.Util.DotNet/Triage/Migrations/20201208163208_IndexNameAndId.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201208163208_IndexNameAndId.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20201208163208_IndexNameAndId")]
+    partial class IndexNameAndId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DevOps.Util.DotNet/Triage/Migrations/20201208163208_IndexNameAndId.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20201208163208_IndexNameAndId.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class IndexNameAndId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelBuilds_DefinitionName_StartTime",
+                table: "ModelBuilds",
+                columns: new[] { "DefinitionName", "StartTime" })
+                .Annotation("SqlServer:Include", new[] { "BuildNumber", "BuildResult", "PullRequestNumber", "GitHubRepository" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionName",
+                table: "ModelBuilds",
+                columns: new[] { "StartTime", "DefinitionName" })
+                .Annotation("SqlServer:Include", new[] { "BuildNumber", "BuildResult", "PullRequestNumber", "GitHubRepository" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelBuilds_DefinitionName_StartTime",
+                table: "ModelBuilds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ModelBuilds_StartTime_DefinitionName",
+                table: "ModelBuilds");
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Model.cs
+++ b/DevOps.Util.DotNet/Triage/Model.cs
@@ -74,6 +74,14 @@ namespace DevOps.Util.DotNet.Triage
                 .HasIndex(x => new { x.DefinitionId, x.StartTime })
                 .IncludeProperties(x => new { x.BuildNumber, x.BuildResult, x.PullRequestNumber, x.GitHubRepository });
 
+            modelBuilder.Entity<ModelBuild>()
+                .HasIndex(x => new { x.StartTime, x.DefinitionName })
+                .IncludeProperties(x => new { x.BuildNumber, x.BuildResult, x.PullRequestNumber, x.GitHubRepository });
+
+            modelBuilder.Entity<ModelBuild>()
+                .HasIndex(x => new { x.DefinitionName, x.StartTime })
+                .IncludeProperties(x => new { x.BuildNumber, x.BuildResult, x.PullRequestNumber, x.GitHubRepository });
+
             modelBuilder.Entity<ModelBuildAttempt>()
                 .HasIndex(x => new { x.Attempt, x.ModelBuildId })
                 .IsUnique();

--- a/DevOps.Util.DotNet/Triage/ModelDataUtil.cs
+++ b/DevOps.Util.DotNet/Triage/ModelDataUtil.cs
@@ -105,7 +105,7 @@ namespace DevOps.Util.DotNet.Triage
                     var dotNetTestRun = await QueryUtil.GetDotNetTestRunAsync(
                         build,
                         testRun,
-                        DotNetUtil.FailedTestOutcomes,
+                        DevOpsUtil.FailedTestOutcomes,
                         includeSubResults: true,
                         onError: ex => Logger.LogWarning($"Error fetching test data {ex.Message}")).ConfigureAwait(false);
                     if (dotNetTestRun.TestCaseResults.Count > maxTestCaseResultCount)

--- a/DevOps.Util.DotNet/Triage/SearchBuildsRequest.cs
+++ b/DevOps.Util.DotNet/Triage/SearchBuildsRequest.cs
@@ -30,17 +30,9 @@ namespace DevOps.Util.DotNet.Triage
         {
             get
             {
-                if (!string.IsNullOrEmpty(Definition))
+                if (!string.IsNullOrEmpty(Definition) && int.TryParse(Definition, out int id))
                 {
-                    if (DotNetUtil.TryGetDefinitionId(Definition, out var _, out var id))
-                    {
-                        return id;
-                    }
-
-                    if (int.TryParse(Definition, out id))
-                    {
-                        return id;
-                    }
+                    return id;
                 }
 
                 return null;
@@ -78,7 +70,7 @@ namespace DevOps.Util.DotNet.Triage
                 : Repository.ToLower();
             string? gitHubOrganization = gitHubRepository is null
                 ? null
-                : DotNetUtil.GitHubOrganization;
+                : DotNetConstants.GitHubOrganization;
 
             if (definitionId is object && definitionName is object)
             {
@@ -136,7 +128,6 @@ namespace DevOps.Util.DotNet.Triage
             {
                 query = query.Where(convertPredicateFunc(x => x.GitHubRepository == gitHubRepository));
             }
-
 
             if (TargetBranch is { } targetBranch)
             {

--- a/DevOps.Util.DotNet/Triage/StatusPageUtil.cs
+++ b/DevOps.Util.DotNet/Triage/StatusPageUtil.cs
@@ -67,9 +67,11 @@ namespace DevOps.Util.DotNet.Triage
             header.AppendLine("## Overview");
             header.AppendLine("Please use these queries to discover issues");
 
-            await BuildOne("Blocking CI", "blocking-clean-ci", DotNetUtil.GetDefinitionKeyFromFriendlyName("runtime")).ConfigureAwait(false);
-            await BuildOne("Blocking Official Build", "blocking-official-build", DotNetUtil.GetDefinitionKeyFromFriendlyName("runtime-official")).ConfigureAwait(false);
-            await BuildOne("Blocking CI Optional", "blocking-clean-ci-optional", DotNetUtil.GetDefinitionKeyFromFriendlyName("runtime"));
+            var runtimeDefinition = await TriageContextUtil.GetModelBuildDefinitionAsync(id: 686).ConfigureAwait(false);
+            var runtimeDefinitionKey = runtimeDefinition.GetDefinitionKey();
+
+            await BuildOne("Blocking CI", "blocking-clean-ci", runtimeDefinitionKey);
+            await BuildOne("Blocking CI Optional", "blocking-clean-ci-optional", runtimeDefinitionKey);
             await BuildOne("Blocking Outerloop", "blocking-outerloop", null);
 
             // Blank line to move past the table 

--- a/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
+++ b/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
@@ -343,6 +343,16 @@ namespace DevOps.Util.DotNet.Triage
         public Task<ModelTestRun> GetModelTestRunAsync(BuildKey buildKey, int testRunId) =>
             GetModelTestRunQuery(buildKey, testRunId).SingleAsync()!;
 
+        public IQueryable<ModelBuildDefinition> GetModelBuildDefinitionQueryAsync(int id) => Context
+            .ModelBuildDefinitions
+            .Where(x => x.DefinitionId == id);
+
+        public Task<ModelBuildDefinition?> FindModelBuildDefinitionAsync(int id) =>
+            GetModelBuildDefinitionQueryAsync(id).FirstOrDefaultAsync()!;
+
+        public Task<ModelBuildDefinition> GetModelBuildDefinitionAsync(int id) =>
+            GetModelBuildDefinitionQueryAsync(id).SingleOrDefaultAsync();
+
         public async Task<ModelBuildDefinition?> FindModelBuildDefinitionAsync(string nameOrId)
         {
             if (int.TryParse(nameOrId, out var id))
@@ -354,20 +364,9 @@ namespace DevOps.Util.DotNet.Triage
                     .ConfigureAwait(false);
             }
 
-            var modelBuildDefinition = await Context
-                .ModelBuildDefinitions
-                .Where(x => x.DefinitionName == nameOrId)
-                .FirstOrDefaultAsync()
-                .ConfigureAwait(false);
-
-            if (modelBuildDefinition is object)
-            {
-                return modelBuildDefinition;
-            }
-
             return await Context
                 .ModelBuildDefinitions
-                .Where(x => EF.Functions.Like(x.DefinitionName, nameOrId))
+                .Where(x => x.DefinitionName == nameOrId)
                 .FirstOrDefaultAsync()
                 .ConfigureAwait(false);
         }

--- a/DevOps.Util.UnitTests/StandardTestBase.cs
+++ b/DevOps.Util.UnitTests/StandardTestBase.cs
@@ -137,7 +137,7 @@ namespace DevOps.Util.UnitTests
 
             var issue = new ModelGitHubIssue()
             {
-                Organization = GetPartOrNull(parts, 0) ?? DotNetUtil.GitHubOrganization,
+                Organization = GetPartOrNull(parts, 0) ?? DotNetConstants.GitHubOrganization,
                 Repository = GetPartOrNull(parts, 1) ?? "roslyn",
                 Number = GetPartOrNull(parts, 2) is { } part ? int.Parse(part) : GitHubIssueCount++,
                 ModelBuild = build,

--- a/DevOps.Util/DevOpsUtil.cs
+++ b/DevOps.Util/DevOpsUtil.cs
@@ -15,6 +15,12 @@ namespace DevOps.Util
 {
     public static class DevOpsUtil
     {
+        public static TestOutcome[] FailedTestOutcomes => new[]
+        {
+            TestOutcome.Failed,
+            TestOutcome.Aborted
+        };
+
         public static BuildKey GetBuildKey(Build build)
         {
             var organization = GetOrganization(build);

--- a/runfo/DotNetUtil.cs
+++ b/runfo/DotNetUtil.cs
@@ -9,8 +9,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading.Tasks;
 using Octokit;
+using DevOps.Util.DotNet;
 
-namespace DevOps.Util.DotNet
+namespace Runfo
 {
     public static class DotNetUtil
     {

--- a/scratch/Queries/PerformanceQueries.sql
+++ b/scratch/Queries/PerformanceQueries.sql
@@ -2,6 +2,19 @@
 /*SELECT COUNT(*) FROM ModelTimelineIssues*/
 SELECT * FROM ModelTestResults
 
+/* Search for timeline issues by definition name not id */
+exec sp_executesql N'SELECT [m1].[BuildNumber], [t].[Message], [t].[JobName], [t].[IssueType], [t].[Attempt]
+FROM (
+    SELECT [m].[Id], [m].[Attempt], [m].[IssueType], [m].[JobName], [m].[Message], [m].[ModelBuildAttemptId], [m].[ModelBuildId], [m].[RecordId], [m].[RecordName], [m].[TaskName], [m0].[BuildNumber]
+    FROM [ModelTimelineIssues] AS [m]
+    LEFT JOIN [ModelBuilds] AS [m0] ON [m].[ModelBuildId] = [m0].[Id]
+    WHERE ([m0].[StartTime] >= @__started_DateTime_Date_0) AND ([m0].[DefinitionName] = @__definitionName_1)
+    ORDER BY [m0].[BuildNumber] DESC
+    OFFSET @__p_2 ROWS FETCH NEXT @__p_3 ROWS ONLY
+) AS [t]
+LEFT JOIN [ModelBuilds] AS [m1] ON [t].[ModelBuildId] = [m1].[Id]
+ORDER BY [t].[BuildNumber] DESC',N'@__started_DateTime_Date_0 datetime,@__definitionName_1 nvarchar(100),@__p_2 int,@__p_3 int',@__started_DateTime_Date_0='2020-12-01 00:00:00',@__definitionName_1=N'runtime',@__p_2=0,@__p_3=25
+
 /* Search for timeline issues by text */
 SELECT [m1].[BuildNumber], [t].[Message], [t].[JobName], [t].[IssueType], [t].[Attempt]
 FROM (


### PR DESCRIPTION
This change removes hard coded build definition names and ids. All of
the indexes in SQL were based off of IDs. That meant only the hard coded
, and possbly stale, values were quick here. Changed the index to be on
name and ID and removed the table from the web app