### PR TITLE
Fix exception during DownloadZipFileAsync on slow servers

### DIFF
--- a/DevOps.Util/DevOpsHttpClient.cs
+++ b/DevOps.Util/DevOpsHttpClient.cs
@@ -52,7 +52,7 @@ namespace DevOps.Util
         internal async Task DownloadFileAsync(string uri, Stream destinationStream)
         {
             var message = CreateHttpRequestMessage(HttpMethod.Get, uri);
-            using var response = await HttpClient.SendAsync(message).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(message, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             await response.Content.CopyToAsync(destinationStream).ConfigureAwait(false);
         }
@@ -61,7 +61,7 @@ namespace DevOps.Util
         {
             var message = CreateHttpRequestMessage(HttpMethod.Get, uri);
             message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/zip"));
-            using var response = await HttpClient.SendAsync(message).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(message, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             await response.Content.CopyToAsync(destinationStream).ConfigureAwait(false);
         }


### PR DESCRIPTION
When downloading payloads from the blob storage container outside its region (West US) the download speeds are often quite slow.
This can result in the following exception since the HttpClient by default blocks to read the whole content with the `SendAsync(HttpRequestMessage)` overload: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.sendasync?view=net-5.0#System_Net_Http_HttpClient_SendAsync_System_Net_Http_HttpRequestMessage_

```
$ runfo get-helix-payload -j bb13fcf7-c48c-4027-9d8b-d05deade8e68 -o .
Payload chrome-linux.zip => /Users/alexander/dev/test/helixpayload/./correlation-payload/chrome-linux.zip
Payload chromedriver_linux64.zip => /Users/alexander/dev/test/helixpayload/./correlation-payload/chromedriver_linux64.zip
Payload f96d025b-4bdd-425e-9bbc-9152506b9ca5.zip => /Users/alexander/dev/test/helixpayload/./correlation-payload/f96d025b-4bdd-425e-9bbc-9152506b9ca5.zip
The operation was canceled.
   at System.Net.Http.HttpConnection.ContentLengthReadStream.CompleteCopyToAsync(Task copyTask, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionResponseContent.SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken)
   at System.Net.Http.HttpContent.LoadIntoBufferAsyncCore(Task serializeToStreamTask, MemoryStream tempBuffer)
   at System.Net.Http.HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at DevOps.Util.DevOpsHttpClient.DownloadZipFileAsync(String uri, Stream destinationStream) in P:\runfo\DevOps.Util\DevOpsHttpClient.cs:line 64
   at DevOps.Util.DevOpsHttpClient.WithFileStream(String destinationFilePath, Func`2 func) in P:\runfo\DevOps.Util\DevOpsHttpClient.cs:line 75
   at DevOps.Util.HelixServer.GetHelixPayloads(String jobId, List`1 workItems, String downloadDir) in P:\runfo\DevOps.Util\HelixServer.cs:line 62
   at Runfo.RuntimeInfo.GetHelixPayload(IEnumerable`1 args) in P:\runfo\runfo\RuntimeInfo.cs:line 1132
   at Runfo.Program.<>c__DisplayClass0_0.<<Main>g__RunCommand|0>d.MoveNext() in P:\runfo\runfo\Program.cs:line 93
--- End of stack trace from previous location where exception was thrown ---
   at Runfo.Program.Main(String[] args) in P:\runfo\runfo\Program.cs:line 53
   at Runfo.Program.Main(String[] args) in P:\runfo\runfo\Program.cs:line 58
```

The fix is to only wait until the response headers are read before reading the content stream.

/cc @jaredpar 