### PR TITLE
Include workitem result files in get-helix-payload

### DIFF
--- a/DevOps.Util/DevOpsHttpClient.cs
+++ b/DevOps.Util/DevOpsHttpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -49,25 +50,75 @@ namespace DevOps.Util
             HttpClient = httpClient ?? new HttpClient();
         }
 
-        internal async Task DownloadFileAsync(string uri, Stream destinationStream)
+        private async Task DownloadWithProgress(HttpResponseMessage response, Stream destinationStream)
+        {
+            Console.Write($"Downloading...");
+            using Stream contentStream = await response.Content.ReadAsStreamAsync();
+
+            long totalRead = 0L;
+            long totalReads = 0L;
+            byte[] buffer = new byte[8192];
+            const double mbdividend = 1000000.0;
+            double sizeInMbs = long.Parse(response.Content.Headers.GetValues("Content-Length").First()) / mbdividend;
+
+            while (true)
+            {
+                int read = await contentStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+                await destinationStream.WriteAsync(buffer, 0, read).ConfigureAwait(false);
+                totalRead += read;
+                totalReads += 1;
+
+                if (totalReads % 500 == 0)
+                {
+                    Console.Write($"\rDownloading... {totalRead / mbdividend:0,0.00}/{sizeInMbs:0,0.00}MBs");
+                }
+            }
+            Console.Write($"\r{new string(' ', Console.BufferWidth)}\b\r"); // clear status line from console.
+        }
+
+        internal async Task DownloadFileAsync(string uri, Stream destinationStream, bool showProgress = false)
         {
             var message = CreateHttpRequestMessage(HttpMethod.Get, uri);
             using var response = await HttpClient.SendAsync(message, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            await response.Content.CopyToAsync(destinationStream).ConfigureAwait(false);
+
+            if (!showProgress)
+            {
+                await response.Content.CopyToAsync(destinationStream).ConfigureAwait(false);
+            }
+            else
+            {
+                await DownloadWithProgress(response, destinationStream).ConfigureAwait(false);
+            }
+
         }
 
-        internal async Task DownloadZipFileAsync(string uri, Stream destinationStream)
+        internal Task DownloadFileAsync(string uri, string destinationFilePath, bool showProgress = false) =>
+            WithFileStream(destinationFilePath, fileStream => DownloadFileAsync(uri, fileStream, showProgress));
+
+        internal async Task DownloadZipFileAsync(string uri, Stream destinationStream, bool showProgress = false)
         {
             var message = CreateHttpRequestMessage(HttpMethod.Get, uri);
             message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/zip"));
             using var response = await HttpClient.SendAsync(message, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            await response.Content.CopyToAsync(destinationStream).ConfigureAwait(false);
+
+            if (!showProgress)
+            {
+                await response.Content.CopyToAsync(destinationStream).ConfigureAwait(false);
+            }
+            else
+            {
+                await DownloadWithProgress(response, destinationStream).ConfigureAwait(false);
+            }
         }
 
-        internal Task DownloadZipFileAsync(string uri, string destinationFilePath) =>
-            WithFileStream(destinationFilePath, fileStream => DownloadZipFileAsync(uri, fileStream));
+        internal Task DownloadZipFileAsync(string uri, string destinationFilePath, bool showProgress = false) =>
+            WithFileStream(destinationFilePath, fileStream => DownloadZipFileAsync(uri, fileStream, showProgress));
 
         internal async Task WithFileStream(string destinationFilePath, Func<FileStream, Task> func)
         {

--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -110,7 +110,7 @@ namespace DevOps.Util
                     IEnumerable<UploadedFile> workitemFiles = await helixApi.WorkItem.ListFilesAsync(workItemId, jobId);
                     foreach (var file in workitemFiles)
                     {
-                        if (ignoreDumps && file.Name.StartsWith("core.") || file.Name.EndsWith(".dmp"))
+                        if (ignoreDumps && (file.Name.StartsWith("core.") || file.Name.EndsWith(".dmp")))
                             continue;
 
                         string destFile = Path.Combine(itemDir, file.Name);

--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -62,7 +62,7 @@ namespace DevOps.Util
                     string fileName = uri.Segments[^1];
                     string destinationFile = Path.Combine(correlationDir, fileName);
                     Console.WriteLine($"Payload {fileName} => {destinationFile}");
-                    await _client.DownloadZipFileAsync(url, destinationFile, showProgress: true).ConfigureAwait(false);
+                    await _client.DownloadZipFileAsync(url, destinationFile, showProgress: true, writer: Console.Out).ConfigureAwait(false);
                 }
 
                 string workItemsDir = Path.Combine(downloadDir, "workitems");
@@ -105,18 +105,18 @@ namespace DevOps.Util
 
                     Console.WriteLine($"WorkItem {workItemId} => {fileName}");
 
-                    await _client.DownloadZipFileAsync(payloadUri, fileName, showProgress: true).ConfigureAwait(false);
+                    await _client.DownloadZipFileAsync(payloadUri, fileName, showProgress: true, writer: Console.Out).ConfigureAwait(false);
 
                     IEnumerable<UploadedFile> workitemFiles = await helixApi.WorkItem.ListFilesAsync(workItemId, jobId);
                     foreach (var file in workitemFiles)
                     {
-                        if (ignoreDumps && (file.Name.StartsWith("core.") || file.Name.EndsWith(".dmp")))
+                        if (ignoreDumps && (file.Name.StartsWith("core.", StringComparison.OrdinalIgnoreCase) || file.Name.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase)))
                             continue;
 
                         string destFile = Path.Combine(itemDir, file.Name);
 
                         Console.WriteLine($"{file.Name} => {destFile}");
-                        await _client.DownloadFileAsync(file.Link, destFile, showProgress: true).ConfigureAwait(false);
+                        await _client.DownloadFileAsync(file.Link, destFile, showProgress: true, writer: Console.Out).ConfigureAwait(false);
                     }
                 }
             }

--- a/runfo/GetFromHelixOptionSet.cs
+++ b/runfo/GetFromHelixOptionSet.cs
@@ -14,11 +14,14 @@ namespace Runfo
 
         internal string? Token { get; set; }
 
+        internal bool IgnoreDumps { get; set; }
+
         internal GetFromHelixOptionSet()
         {
             Add("j|jobid=", "helix job id to download items from.", j => JobId = j);
             Add("o|output=", "output directory to download to.", d => DownloadDir = d);
-            Add("w|workitems=", "comma separated list of workitems to download.\nAccepted values:\nempty: download only correlation payload.\nlist: separated by comma.\nall: download all workitems.", w => WorkItems = w.Split(",").ToList());
+            Add("n|no-dumps", "don't download dump files if any.", nd => IgnoreDumps = nd is object);
+            Add("w|workitems=", "Accepted values:\n empty: first workitem.\n list: workitem name(s) separated by comma.\n all: download all workitems.", w => WorkItems = w.Split(",").ToList());
         }
     }
 }

--- a/runfo/RuntimeInfo.cs
+++ b/runfo/RuntimeInfo.cs
@@ -1129,7 +1129,7 @@ namespace Runfo
                 return ReturnWithFailureMessage("Output directory should not be empty");
             }
 
-            await HelixServer.GetHelixPayloads(optionSet.JobId, optionSet.WorkItems, optionSet.DownloadDir).ConfigureAwait(false);
+            await HelixServer.GetHelixPayloads(optionSet.JobId, optionSet.WorkItems, optionSet.DownloadDir, optionSet.IgnoreDumps).ConfigureAwait(false);
 
             int ReturnWithFailureMessage(string message)
             {


### PR DESCRIPTION
This change includes files uploaded by a workitem (console.log, dumps, etc). This is helpful as that way people can have everything downloaded rather than just the payload and have to figure out where to get a dump or a console log from.

Also as part of this change I changed the meaning of empty workitems as an argument. Before it would just download the correlation payloads, now it downloads the first workitem with a payload it finds. This is feedback people gave me as it is useful if you don't know a workitem name and just want to look at the correlation payload or the workitem structure to make sure you got things right when adding a new run or debugging something weird happening with the payload, etc.

Since I noticed dumps can take a few mins to download or even payloads can take more than 5/10 seconds, I added download progress to the console so that the user knows it is doing work and how much it is left to download.

Also, for people that don't care about the dump to avoid waiting for a few mins for it to download I added a flag to be able to ignore dumps from the download.

cc: @jaredpar @akoeplinger @danmoseley