### PR TITLE
Working out issues with timeouts

### DIFF
--- a/scratch/Program.cs
+++ b/scratch/Program.cs
@@ -107,7 +107,8 @@ namespace Scratch
             var message = connectionString.Contains("triage-scratch-dev")
                 ? "Using sql developer"
                 : "Using sql production";
-            builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(5).TotalSeconds));
+            builder.UseSqlServer(connectionString);
+            //builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(5).TotalSeconds));
                 //builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(145).TotalSeconds));
 
             // builder.UseLoggerFactory(LoggerFactory.Create(builder => builder.AddConsole()));


### PR DESCRIPTION
Timeout issues appear to be happening because deletes are slow for the
tables with large amount of indexes. Moved to deleting these in smaller
batches to avoid the index hit. This seems to work better with the
existing timeout logic.