### PR TITLE
Use cascade delete for entities

### DIFF
--- a/DevOps.Util.DotNet/Function/FunctionUtil.cs
+++ b/DevOps.Util.DotNet/Function/FunctionUtil.cs
@@ -52,7 +52,7 @@ namespace DevOps.Util.DotNet.Function
         /// </summary>
         public async Task DeleteOldBuilds(TriageContext triageContext, int deleteMax = 25)
         {
-            var limitDays = 120;
+            var limitDays = 90;
             var limit = DateTime.UtcNow - TimeSpan.FromDays(limitDays);
 
             var modelBuilds = await triageContext
@@ -69,50 +69,8 @@ namespace DevOps.Util.DotNet.Function
                     Logger.LogInformation($"Deleting {modelBuild.GetBuildKey()} ran at {modelBuild.StartTime}");
                 }
 
-                await RemoveRange(triageContext.ModelOsxDeprovisionRetry.Where(x => x.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveRange(triageContext.ModelBuildAttempts.Where(x => x.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveRange(triageContext.ModelGitHubIssues.Where(x => x.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveRange(triageContext.ModelTrackingIssueMatches.Where(x => x.ModelBuildAttempt.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveRange(triageContext.ModelTrackingIssueMatches.Where(x => x.ModelBuildAttempt.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveRange(triageContext.ModelTrackingIssueResults.Where(x => x.ModelBuildAttempt.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await triageContext.SaveChangesAsync().ConfigureAwait(false);
-
-                // These tables have a lot of indexes against them and delete can be slow, enough so 
-                // that it will timeout the Sql Connection if we attempt to delete all entries at 
-                // a single time. To compensate we delete them in smaller batches.
-                await RemoveBatch(() => triageContext.ModelTimelineIssues.Where(x => x.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveBatch(() => triageContext.ModelTestRuns.Where(x => x.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-                await RemoveBatch(() => triageContext.ModelTestResults.Where(x => x.ModelBuildId == modelBuild.Id)).ConfigureAwait(false);
-
                 triageContext.Remove(modelBuild);
                 await triageContext.SaveChangesAsync().ConfigureAwait(false);
-
-                async Task RemoveBatch<TEntity>(Func<IQueryable<TEntity>> func) where TEntity : class
-                {
-                    do
-                    {
-                        var list = await func().Take(50).ToListAsync().ConfigureAwait(false);
-                        if (list.Count == 0)
-                        {
-                            break;
-                        }
-
-                        Logger.LogInformation($"Deleting {list.Count} {typeof(TEntity).Name}");
-                        triageContext.RemoveRange(list);
-                        await triageContext.SaveChangesAsync().ConfigureAwait(false);
-
-                    } while (true);
-                }
-            }
-
-            async Task RemoveRange<TEntity>(IQueryable<TEntity> queryable) where TEntity : class
-            {
-                var list = await queryable.ToListAsync().ConfigureAwait(false);
-                if (list.Count > 0)
-                {
-                    Logger.LogInformation($"Deleting {list.Count} {typeof(TEntity).Name}");
-                    triageContext.RemoveRange(list);
-                }
             }
         }
     }

--- a/DevOps.Util.DotNet/Triage/Migrations/20210331154929_CascadeDelete.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20210331154929_CascadeDelete.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20210331154929_CascadeDelete")]
+    partial class CascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -502,8 +504,7 @@ namespace DevOps.Util.DotNet.Triage.Migrations
                 {
                     b.HasOne("DevOps.Util.DotNet.Triage.ModelBuild", "ModelBuild")
                         .WithMany()
-                        .HasForeignKey("ModelBuildId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey("ModelBuildId");
                 });
 
             modelBuilder.Entity("DevOps.Util.DotNet.Triage.ModelTestResult", b =>
@@ -516,7 +517,7 @@ namespace DevOps.Util.DotNet.Triage.Migrations
                     b.HasOne("DevOps.Util.DotNet.Triage.ModelTestRun", "ModelTestRun")
                         .WithMany()
                         .HasForeignKey("ModelTestRunId")
-                        .OnDelete(DeleteBehavior.NoAction)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
@@ -524,8 +525,7 @@ namespace DevOps.Util.DotNet.Triage.Migrations
                 {
                     b.HasOne("DevOps.Util.DotNet.Triage.ModelBuild", "ModelBuild")
                         .WithMany()
-                        .HasForeignKey("ModelBuildId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey("ModelBuildId");
                 });
 
             modelBuilder.Entity("DevOps.Util.DotNet.Triage.ModelTimelineIssue", b =>

--- a/DevOps.Util.DotNet/Triage/Migrations/20210331154929_CascadeDelete.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20210331154929_CascadeDelete.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class CascadeDelete : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelBuildAttempts_ModelBuilds_ModelBuildId",
+                table: "ModelBuildAttempts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelGitHubIssues_ModelBuilds_ModelBuildId",
+                table: "ModelGitHubIssues");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTestResults_ModelBuilds_ModelBuildId",
+                table: "ModelTestResults");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTimelineIssues_ModelBuildAttempts_ModelBuildAttemptId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTimelineIssues_ModelBuilds_ModelBuildId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ModelTimelineIssues_ModelBuildAttemptId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.DropColumn(
+                name: "ModelBuildAttemptId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelBuildAttempts_ModelBuilds_ModelBuildId",
+                table: "ModelBuildAttempts",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelGitHubIssues_ModelBuilds_ModelBuildId",
+                table: "ModelGitHubIssues",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTestResults_ModelBuilds_ModelBuildId",
+                table: "ModelTestResults",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTimelineIssues_ModelBuilds_ModelBuildId",
+                table: "ModelTimelineIssues",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelBuildAttempts_ModelBuilds_ModelBuildId",
+                table: "ModelBuildAttempts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelGitHubIssues_ModelBuilds_ModelBuildId",
+                table: "ModelGitHubIssues");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTestResults_ModelBuilds_ModelBuildId",
+                table: "ModelTestResults");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTimelineIssues_ModelBuilds_ModelBuildId",
+                table: "ModelTimelineIssues");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ModelBuildAttemptId",
+                table: "ModelTimelineIssues",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelTimelineIssues_ModelBuildAttemptId",
+                table: "ModelTimelineIssues",
+                column: "ModelBuildAttemptId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelBuildAttempts_ModelBuilds_ModelBuildId",
+                table: "ModelBuildAttempts",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelGitHubIssues_ModelBuilds_ModelBuildId",
+                table: "ModelGitHubIssues",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTestResults_ModelBuilds_ModelBuildId",
+                table: "ModelTestResults",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTimelineIssues_ModelBuildAttempts_ModelBuildAttemptId",
+                table: "ModelTimelineIssues",
+                column: "ModelBuildAttemptId",
+                principalTable: "ModelBuildAttempts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTimelineIssues_ModelBuilds_ModelBuildId",
+                table: "ModelTimelineIssues",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Migrations/20210331170735_CascadeDelete2.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20210331170735_CascadeDelete2.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20210331170735_CascadeDelete2")]
+    partial class CascadeDelete2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DevOps.Util.DotNet/Triage/Migrations/20210331170735_CascadeDelete2.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20210331170735_CascadeDelete2.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class CascadeDelete2 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelOsxDeprovisionRetry_ModelBuilds_ModelBuildId",
+                table: "ModelOsxDeprovisionRetry");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTestResults_ModelTestRuns_ModelTestRunId",
+                table: "ModelTestResults");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTestRuns_ModelBuilds_ModelBuildId",
+                table: "ModelTestRuns");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelOsxDeprovisionRetry_ModelBuilds_ModelBuildId",
+                table: "ModelOsxDeprovisionRetry",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTestResults_ModelTestRuns_ModelTestRunId",
+                table: "ModelTestResults",
+                column: "ModelTestRunId",
+                principalTable: "ModelTestRuns",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTestRuns_ModelBuilds_ModelBuildId",
+                table: "ModelTestRuns",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelOsxDeprovisionRetry_ModelBuilds_ModelBuildId",
+                table: "ModelOsxDeprovisionRetry");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTestResults_ModelTestRuns_ModelTestRunId",
+                table: "ModelTestResults");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModelTestRuns_ModelBuilds_ModelBuildId",
+                table: "ModelTestRuns");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelOsxDeprovisionRetry_ModelBuilds_ModelBuildId",
+                table: "ModelOsxDeprovisionRetry",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTestResults_ModelTestRuns_ModelTestRunId",
+                table: "ModelTestResults",
+                column: "ModelTestRunId",
+                principalTable: "ModelTestRuns",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModelTestRuns_ModelBuilds_ModelBuildId",
+                table: "ModelTestRuns",
+                column: "ModelBuildId",
+                principalTable: "ModelBuilds",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Model.cs
+++ b/DevOps.Util.DotNet/Triage/Model.cs
@@ -90,6 +90,11 @@ namespace DevOps.Util.DotNet.Triage
                 .HasIndex(x => new { x.Attempt, x.ModelBuildId })
                 .IsUnique();
 
+            modelBuilder.Entity<ModelBuildAttempt>()
+                .HasOne(x => x.ModelBuild)
+                .WithMany(x => x.ModelBuildAttempts)
+                .OnDelete(DeleteBehavior.Cascade);
+
             modelBuilder.Entity<ModelBuildDefinition>()
                 .HasIndex(x => new { x.AzureOrganization, x.AzureProject, x.DefinitionId })
                 .IsUnique();
@@ -102,6 +107,11 @@ namespace DevOps.Util.DotNet.Triage
                 .Property(x => x.Attempt)
                 .HasDefaultValue(1);
 
+            modelBuilder.Entity<ModelTestRun>()
+                .HasOne(x => x.ModelBuild)
+                .WithMany()
+                .OnDelete(DeleteBehavior.Cascade);
+
             modelBuilder.Entity<ModelTestResult>()
                 .HasIndex(x => x.ModelBuildId)
                 .IncludeProperties(x => new { x.TestFullName, x.JobName, x.IsHelixTestResult });
@@ -109,6 +119,16 @@ namespace DevOps.Util.DotNet.Triage
             modelBuilder.Entity<ModelTestResult>()
                 .Property(x => x.JobName)
                 .HasDefaultValue("");
+
+            modelBuilder.Entity<ModelTestResult>()
+                .HasOne(x => x.ModelBuild)
+                .WithMany(x => x.ModelTestResults)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<ModelTestResult>()
+                .HasOne(x => x.ModelTestRun)
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
 
             modelBuilder.Entity<ModelTimelineIssue>()
                 .Property(x => x.IssueType)
@@ -122,6 +142,11 @@ namespace DevOps.Util.DotNet.Triage
             modelBuilder.Entity<ModelTimelineIssue>()
                 .HasIndex(x => new { x.Attempt, x.ModelBuildId });
 
+            modelBuilder.Entity<ModelTimelineIssue>()
+                .HasOne(x => x.ModelBuild)
+                .WithMany(x => x.ModelTimelineIssues)
+                .OnDelete(DeleteBehavior.Cascade);
+
             modelBuilder.Entity<ModelTrackingIssue>()
                 .Property(x => x.TrackingKind)
                 .HasConversion<string>();
@@ -133,9 +158,19 @@ namespace DevOps.Util.DotNet.Triage
             modelBuilder.Entity<ModelTrackingIssueMatch>()
                 .HasIndex(x => x.ModelTrackingIssueId);
 
+            modelBuilder.Entity<ModelTrackingIssueMatch>()
+                .HasOne(x => x.ModelBuildAttempt)
+                .WithMany(x => x.ModelTrackingIssueMatches)
+                .OnDelete(DeleteBehavior.Cascade);
+
             modelBuilder.Entity<ModelTrackingIssueResult>()
                 .HasIndex(x => new { x.ModelTrackingIssueId, x.ModelBuildAttemptId })
                 .IsUnique();
+
+            modelBuilder.Entity<ModelTrackingIssueResult>()
+                .HasOne(x => x.ModelBuildAttempt)
+                .WithMany(x => x.ModelTrackingIssueResults)
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<ModelGitHubIssue>()
                 .HasIndex(x => new { x.Organization, x.Repository, x.Number, x.ModelBuildId })
@@ -143,6 +178,16 @@ namespace DevOps.Util.DotNet.Triage
 
             modelBuilder.Entity<ModelGitHubIssue>()
                 .HasIndex(x => new { x.Number, x.Organization, x.Repository });
+
+            modelBuilder.Entity<ModelGitHubIssue>()
+                .HasOne(x => x.ModelBuild)
+                .WithMany(x => x.ModelGitHubIssues)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<ModelOsxDeprovisionRetry>()
+                .HasOne(x => x.ModelBuild)
+                .WithMany()
+                .OnDelete(DeleteBehavior.Cascade);
         }
     }
 
@@ -289,8 +334,6 @@ namespace DevOps.Util.DotNet.Triage
 
         public ModelBuild ModelBuild { get; set; }
 
-        public List<ModelTimelineIssue> ModelTimelineIssues { get; set; }
-
         public List<ModelTrackingIssueMatch> ModelTrackingIssueMatches { get; set; }
 
         public List<ModelTrackingIssueResult> ModelTrackingIssueResults { get; set; }
@@ -323,10 +366,6 @@ namespace DevOps.Util.DotNet.Triage
         public string ModelBuildId { get; set; }
 
         public ModelBuild ModelBuild { get; set; }
-
-        public int ModelBuildAttemptId { get; set; }
-
-        public ModelBuildAttempt ModelBuildAttempt { get; set; } 
     }
 
     public class ModelTestRun

--- a/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
+++ b/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
@@ -228,7 +228,6 @@ namespace DevOps.Util.DotNet.Triage
                         Message = issue.Message,
                         ModelBuild = modelBuild,
                         IssueType = issue.Type,
-                        ModelBuildAttempt = modelBuildAttempt,
                     };
                     Context.ModelTimelineIssues.Add(timelineIssue);
                 }

--- a/DevOps.Util.UnitTests/StandardTestBase.cs
+++ b/DevOps.Util.UnitTests/StandardTestBase.cs
@@ -72,7 +72,6 @@ namespace DevOps.Util.UnitTests
                 JobName = parts[0],
                 Message = parts[1],
                 RecordName = parts.Length > 2 ? parts[2] : null,
-                ModelBuildAttempt = attempt,
                 ModelBuild = attempt.ModelBuild,
             };
             Context.ModelTimelineIssues.Add(issue);

--- a/scratch/Queries/Scratch.sql
+++ b/scratch/Queries/Scratch.sql
@@ -10,6 +10,20 @@ ORDER BY [m0].[BuildNumber] DESC
 OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
 */
 
+/* Show all foreign keys including cascade actions */
+ SELECT
+    f.name constraint_name
+   ,OBJECT_NAME(f.parent_object_id) referencing_table_name
+   ,COL_NAME(fc.parent_object_id, fc.parent_column_id) referencing_column_name
+   ,OBJECT_NAME (f.referenced_object_id) referenced_table_name
+   ,COL_NAME(fc.referenced_object_id, fc.referenced_column_id) referenced_column_name
+   ,delete_referential_action_desc
+   ,update_referential_action_desc
+FROM sys.foreign_keys AS f
+INNER JOIN sys.foreign_key_columns AS fc
+   ON f.object_id = fc.constraint_object_id
+ORDER BY f.name
+
 SELECT COUNT(*)
 FROM ModelBuilds
 WHERE AzureProject is NULL
@@ -23,6 +37,42 @@ FROM ModelTestRuns as r
 LEFT JOIN ModelBuilds as b ON b.Id = r.ModelBuildId
 WHERE b.StartTime IS NOT NULl
 ORDER BY b.StartTime 
+
+SELECT COUNT(r.Id)
+FROM ModelTestRuns as r
+LEFT JOIN ModelBuilds as b ON r.ModelBuildId = b.Id
+WHERE b.StartTime < '2020-11-01'
+
+SELECT COUNT(Id)
+FROM ModelBuilds
+WHERE StartTIme < '2020-11-01'
+
+/* Delete Time */
+SELECT COUNT(*)
+FROM ModelTestResults m
+WHERE m.ModelBuildId IN (
+	SELECT Id 
+	FROM ModelBuilds
+	WHERE StartTime < '2020-12-01')
+
+DELETE m
+FROM ModelTestResults m
+WHERE m.ModelBuildId IN (
+	SELECT Id 
+	FROM ModelBuilds
+	WHERE StartTime < '2020-12-01')
+
+DELETE m
+FROM ModelTrackingIssueMatches m
+WHERE m.ModelBuildAttemptId IN (
+	SELECT Id 
+	FROM ModelBuildAttempts
+	WHERE StartTime < '2020-12-15')
+
+SELECT COUNT(m.Id)
+FROM ModelTestResults m
+LEFT JOIN ModelBuilds as b ON m.ModelBuildId = b.Id
+WHERE b.StartTime < '2020-11-01'
 
 
 SELECT TOP 10


### PR DESCRIPTION
My inexperience with EF Core lead to bad cascade delete rules. That
meant when I deleted root entities like `ModelBuild` it didn't properly
cascade down to the dependent entities. That should be fixed now meaning
delete can be a lot simpler and more efficient.