### PR TITLE
Changed tracking util to hit index

### DIFF
--- a/DevOps.Util.DotNet/Triage/Migrations/20210413135754_ModelTestResultsIncludeAttemptInIndex.Designer.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20210413135754_ModelTestResultsIncludeAttemptInIndex.Designer.cs
@@ -4,14 +4,16 @@ using DevOps.Util.DotNet.Triage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DevOps.Util.DotNet.Triage.Migrations
 {
     [DbContext(typeof(TriageContext))]
-    partial class TriageContextModelSnapshot : ModelSnapshot
+    [Migration("20210413135754_ModelTestResultsIncludeAttemptInIndex")]
+    partial class ModelTestResultsIncludeAttemptInIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DevOps.Util.DotNet/Triage/Migrations/20210413135754_ModelTestResultsIncludeAttemptInIndex.cs
+++ b/DevOps.Util.DotNet/Triage/Migrations/20210413135754_ModelTestResultsIncludeAttemptInIndex.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DevOps.Util.DotNet.Triage.Migrations
+{
+    public partial class ModelTestResultsIncludeAttemptInIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelTestResults_ModelBuildId",
+                table: "ModelTestResults");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelTestResults_ModelBuildId_Attempt",
+                table: "ModelTestResults",
+                columns: new[] { "ModelBuildId", "Attempt" })
+                .Annotation("SqlServer:Include", new[] { "TestFullName", "TestRunName", "IsHelixTestResult" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelTestResults_ModelBuildId_Attempt",
+                table: "ModelTestResults");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelTestResults_ModelBuildId",
+                table: "ModelTestResults",
+                column: "ModelBuildId")
+                .Annotation("SqlServer:Include", new[] { "TestFullName", "TestRunName", "IsHelixTestResult" });
+        }
+    }
+}

--- a/DevOps.Util.DotNet/Triage/Model.cs
+++ b/DevOps.Util.DotNet/Triage/Model.cs
@@ -87,7 +87,7 @@ namespace DevOps.Util.DotNet.Triage
                 .IsUnique();
 
             modelBuilder.Entity<ModelTestResult>()
-                .HasIndex(x => x.ModelBuildId)
+                .HasIndex(x => new { x.ModelBuildId, x.Attempt })
                 .IncludeProperties(x => new { x.TestFullName, x.TestRunName, x.IsHelixTestResult });
 
             modelBuilder.Entity<ModelTestResult>()

--- a/DevOps.Util.UnitTests/StandardTestBase.cs
+++ b/DevOps.Util.UnitTests/StandardTestBase.cs
@@ -245,6 +245,7 @@ namespace DevOps.Util.UnitTests
                 StartTime = testRun.ModelBuild.StartTime,
                 ModelBuild = testRun.ModelBuild,
                 ModelBuildAttempt = testRun.ModelBuildAttempt,
+                Attempt = testRun.Attempt,
                 DefinitionNumber = testRun.ModelBuild.DefinitionNumber,
                 DefinitionName = testRun.ModelBuild.DefinitionName,
                 ModelBuildDefinition = testRun.ModelBuild.ModelBuildDefinition,


### PR DESCRIPTION
The tracking util needed to hit the correct indexes. The query should
really just be looking at the issues / tests associated with the current
attempt and filtering those. There is no need to go by started date
first as that is irrelevant at this phase. The only part that matters is
whether or not the attempt matches the other criteria.