### PR TITLE
Reduce tracking query size

### DIFF
--- a/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
+++ b/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
@@ -276,9 +276,12 @@ namespace DevOps.Util.DotNet.Triage
             return modelBuildAttempt;
         }
 
-        public async Task<ModelGitHubIssue> EnsureGitHubIssueAsync(ModelBuild modelBuild, GitHubIssueKey issueKey, bool saveChanges)
+        public Task<ModelGitHubIssue> EnsureGitHubIssueAsync(ModelBuild modelBuild, GitHubIssueKey issueKey, bool saveChanges)
+            => EnsureGitHubIssueAsync(modelBuild.GetBuildKey(), modelBuild.Id, issueKey, saveChanges);
+
+        public async Task<ModelGitHubIssue> EnsureGitHubIssueAsync(BuildKey buildKey, int modelBuildId, GitHubIssueKey issueKey, bool saveChanges)
         {
-            var query = GetModelBuildQuery(modelBuild.GetBuildKey())
+            var query = GetModelBuildQuery(buildKey)
                 .SelectMany(x => x.ModelGitHubIssues)
                 .Where(x =>
                     x.Number == issueKey.Number &&
@@ -295,7 +298,7 @@ namespace DevOps.Util.DotNet.Triage
                 Organization = issueKey.Organization,
                 Repository = issueKey.Repository,
                 Number = issueKey.Number,
-                ModelBuild = modelBuild,
+                ModelBuildId = modelBuildId,
             };
 
             Context.ModelGitHubIssues.Add(modelGitHubIssue);

--- a/DevOps.Util.UnitTests/TrackingIssueUtilTests.cs
+++ b/DevOps.Util.UnitTests/TrackingIssueUtilTests.cs
@@ -240,7 +240,7 @@ namespace DevOps.Util.UnitTests
             async Task TestSearch(ModelTrackingIssue issue, int matchCount, bool isPresent)
             {
                 await Context.SaveChangesAsync();
-                await TrackingIssueUtil.TriageAsync(attempt, issue);
+                await TrackingIssueUtil.TriageAsync(attempt.GetBuildAttemptKey(), issue);
                 var matches = await Context.ModelTrackingIssueMatches.Where(x => x.ModelTrackingIssueId == issue.Id).ToListAsync();
                 Assert.Equal(matchCount, matches.Count);
                 var result = await Context.ModelTrackingIssueResults.Where(x => x.ModelTrackingIssueId == issue.Id).SingleAsync();


### PR DESCRIPTION
The core of the tracking queries is to lookup information on a
`ModelBuildAttempt`. This is returing a lot of unneeded data. It is
likely contributing to the unexpected costs I'm seeing in billing.
Reducing it to just the needed data