### PR TITLE
Use indexes in tracking layer

### DIFF
--- a/DevOps.Util.UnitTests/SearchRequestTests.cs
+++ b/DevOps.Util.UnitTests/SearchRequestTests.cs
@@ -74,12 +74,12 @@ namespace DevOps.Util.UnitTests
         {
             var def = AddBuildDefinition("dnceng|public|roslyn|42");
             var build1 = AddBuild("1|dotnet|roslyn||Failed", def);
-            var testRun1 = AddTestRun("windows", build1);
+            var testRun1 = AddTestRun("windows", AddAttempt(1, build1));
             AddTestResult("Test1||||cat", testRun1);
             AddTestResult("Test2||||cat", testRun1);
             AddTestResult("Test3||||dog", testRun1);
             var build2 = AddBuild("2|dotnet|roslyn||Failed", def);
-            var testRun2 = AddTestRun("windows", build2);
+            var testRun2 = AddTestRun("windows", AddAttempt(1, build2));
             AddTestResult("Test1||||fish", testRun1);
             AddTestResult("Test2||||fish", testRun1);
             AddTestResult("Test3||||cat", testRun1);

--- a/DevOps.Util.UnitTests/StandardTestBase.cs
+++ b/DevOps.Util.UnitTests/StandardTestBase.cs
@@ -207,12 +207,9 @@ namespace DevOps.Util.UnitTests
             return trackingIssue;
         }
 
-        public ModelTestRun AddTestRun(string data, ModelBuild build)
-        {
-            var attempt = AddAttempt(1, build);
-            return AddTestRun(data, attempt);
-        }
-
+        /// <summary>
+        /// |name|?|test run id| 
+        /// </summary>
         public ModelTestRun AddTestRun(string data, ModelBuildAttempt attempt)
         {
             var parts = data.Split("|");
@@ -229,6 +226,9 @@ namespace DevOps.Util.UnitTests
             return testRun;
         }
 
+        /// <summary>
+        /// |test name|is helix|console uri|runclient uri|error message|
+        /// </summary>
         public ModelTestResult AddTestResult(string data, ModelTestRun testRun)
         {
             var parts = data.Split("|");

--- a/scratch/Queries/Scratch.sql
+++ b/scratch/Queries/Scratch.sql
@@ -20,9 +20,36 @@ JOIN ModelBuildAttempts a ON a.Id = m.ModelBuildAttemptId
 SELECT * 
 FROM ModelGitHubISsues
 
-/* random
+/*
+Looking at tracking issue performance 
 */
- DBCC SHRINKDATABASE (N'triage-scratch');
+
+/* query that we started with */ 
+DECLARE @__modelBuild_Id_0 as INteger = 26151
+DECLARE @__key_Attempt_1 As INTEGER = 1
+DECLARE @__Definition_2 AS NVARCHAR(100)='runtime'  
+DECLARE @__Name_3 AS NVARCHAR(1000)='System.Security.Cryptography.Rsa.Tests.EncryptDecrypt_Span.RoundtripEmptyArray' 
+SELECT [m].[Id] AS [ModelTestResultId], [m0].[Name] AS [JobName]
+FROM [ModelTestResults] AS [m]
+INNER JOIN [ModelTestRuns] AS [m0] ON [m].[ModelTestRunId] = [m0].[Id]
+WHERE ((([m].[ModelBuildId] = @__modelBuild_Id_0) AND ([m].[Attempt] = @__key_Attempt_1)) AND ([m].[DefinitionName] = @__Definition_2)) AND ((@__Name_3 = N'') OR (CHARINDEX(@__Name_3, [m].[TestFullName]) > 0))
+
+/* make sure to clear out the definition since we already filtered to that */
+DECLARE @__modelBuild_Id_0 as INteger = 26151
+DECLARE @__key_Attempt_1 As INTEGER = 1
+DECLARE @__Name_2 AS NVARCHAR(1000)='System.Security.Cryptography.Rsa.Tests.EncryptDecrypt_Span.RoundtripEmptyArray' 
+      SELECT [m].[Id] AS [ModelTestResultId], [m0].[Name] AS [JobName]
+      FROM [ModelTestResults] AS [m]
+      INNER JOIN [ModelTestRuns] AS [m0] ON [m].[ModelTestRunId] = [m0].[Id]
+      WHERE (([m].[ModelBuildId] = @__modelBuild_Id_0) AND ([m].[Attempt] = @__key_Attempt_1)) AND ((@__Name_2 = N'') OR (CHARINDEX(@__Name_2, [m].[TestFullName]) > 0))
+
+/* don't join into ModelTestRun anymore because the data is all in the ModelTestResults table */
+DECLARE @__modelBuild_Id_0 as INteger = 26151
+DECLARE @__key_Attempt_1 As INTEGER = 1
+DECLARE @__Name_2 AS NVARCHAR(1000)='System.Security.Cryptography.Rsa.Tests.EncryptDecrypt_Span.RoundtripEmptyArray' 
+      SELECT [m].[Id] AS [ModelTestResultId], [m].[TestRunName] AS [JobName]
+      FROM [ModelTestResults] AS [m]
+      WHERE (([m].[ModelBuildId] = @__modelBuild_Id_0) AND ([m].[Attempt] = @__key_Attempt_1)) AND ((@__Name_2 = N'') OR (CHARINDEX(@__Name_2, [m].[TestFullName]) > 0))
 
 SELECT 
     t.NAME AS TableName,


### PR DESCRIPTION
The tracking issue layer was including several columns in the filters,
including definiton, that caused us to miss key indexes. These columns
were unnecessary though as they are included in the earlier filter.