### PR TITLE
Normalize message based queries

### DIFF
--- a/DevOps.Status/Pages/SearchDoc.cshtml
+++ b/DevOps.Status/Pages/SearchDoc.cshtml
@@ -80,7 +80,7 @@
             <td>Filter to builds against branches that contain main. Use =main for exact match.</td>
         </tr>
         <tr>
-            <td class="font-weight-bold">text:error</td>
+            <td class="font-weight-bold">message:error</td>
             <td>Filters to the logs where issue message matches error. Prefix with ^ for CONTAINS and # for CHARINDEX.</td>
         </tr>
         <tr>

--- a/DevOps.Util.DotNet/Triage/SearchTestsRequest.cs
+++ b/DevOps.Util.DotNet/Triage/SearchTestsRequest.cs
@@ -119,6 +119,7 @@ namespace DevOps.Util.DotNet.Triage
                     case "jobname":
                         JobName = tuple.Value.Trim('"');
                         break;
+                    case "text":
                     case "message":
                         Message = tuple.Value.Trim('"');
                         break;

--- a/DevOps.Util.DotNet/Triage/SearchTimelinesRequest.cs
+++ b/DevOps.Util.DotNet/Triage/SearchTimelinesRequest.cs
@@ -18,7 +18,7 @@ namespace DevOps.Util.DotNet.Triage
     {
         public const int DefaultLimit = 50;
 
-        public string? Text { get; set; }
+        public string? Message { get; set; }
         public string? JobName { get; set; }
         public string? DisplayName { get; set; }
         public string? TaskName { get; set; }
@@ -59,14 +59,14 @@ namespace DevOps.Util.DotNet.Triage
             }
 
             // Keep this in sync with logic in SearchTestsRequest
-            if (!string.IsNullOrEmpty(Text))
+            if (!string.IsNullOrEmpty(Message))
             {
-                var c = Text[0];
+                var c = Message[0];
                 query = c switch
                 {
-                    '#' => query = query.Where(x => x.Message.Contains(Text.Substring(1))),
-                    '*' => GetFullText(query, Text.Substring(1)),
-                    _ => GetFullText(query, Text)
+                    '#' => query = query.Where(x => x.Message.Contains(Message.Substring(1))),
+                    '*' => GetFullText(query, Message.Substring(1)),
+                    _ => GetFullText(query, Message)
                 };
 
                 static IQueryable<ModelTimelineIssue> GetFullText(IQueryable<ModelTimelineIssue> query, string text)
@@ -88,9 +88,9 @@ namespace DevOps.Util.DotNet.Triage
             var builder = new StringBuilder();
             GetQueryStringCore(builder);
 
-            if (!string.IsNullOrEmpty(Text))
+            if (!string.IsNullOrEmpty(Message))
             {
-                Append($"text:\"{Text}\"");
+                Append($"message:\"{Message}\"");
             }
 
             if (!string.IsNullOrEmpty(JobName))
@@ -130,7 +130,7 @@ namespace DevOps.Util.DotNet.Triage
         {
             if (!userQuery.Contains(":"))
             {
-                Text = userQuery.Trim('"');
+                Message = userQuery.Trim('"');
                 return;
             }
 
@@ -139,7 +139,8 @@ namespace DevOps.Util.DotNet.Triage
                 switch (tuple.Name.ToLower())
                 {
                     case "text":
-                        Text = tuple.Value.Trim('"');
+                    case "message":
+                        Message = tuple.Value.Trim('"');
                         break;
                     case "jobname":
                         JobName = tuple.Value.Trim('"');

--- a/DevOps.Util.UnitTests/SearchRequestContentTests.cs
+++ b/DevOps.Util.UnitTests/SearchRequestContentTests.cs
@@ -58,22 +58,24 @@ namespace DevOps.Util.UnitTests
         }
 
         [Theory]
-        [InlineData("text:\"error\"", "started:~7 text:\"error\"")]
-        [InlineData("text:\"error and space\"", "started:~7 text:\"error and space\"")]
-        [InlineData("text:\"error and space\"   ", "started:~7 text:\"error and space\"")]
+        [InlineData("message:\"error\"", "started:~7 message:\"error\"")]
+        [InlineData("message:\"error and space\"", "started:~7 message:\"error and space\"")]
+        [InlineData("message:\"error and space\"   ", "started:~7 message:\"error and space\"")]
+        [InlineData("text:\"error\"", "started:~7 message:\"error\"")]
+        [InlineData("text:\"error and space\"", "started:~7 message:\"error and space\"")]
+        [InlineData("text:\"error and space\"   ", "started:~7 message:\"error and space\"")]
         [InlineData("displayName:Installer   ", "started:~7 displayName:\"Installer\"")]
         [InlineData("taskName:Installer   ", "started:~7 taskName:\"Installer\"")]
         [InlineData("taskName:Task displayName:Display", "started:~7 displayName:\"Display\" taskName:\"Task\"")]
-        [InlineData("error", "started:~7 text:\"error\"")]
-        [InlineData("text:error", "started:~7 text:\"error\"")]
-        [InlineData("started:~3 kind:mpr text:error", "started:~3 kind:mpr text:\"error\"")]
+        [InlineData("error", "started:~7 message:\"error\"")]
+        [InlineData("text:error", "started:~7 message:\"error\"")]
+        [InlineData("started:~3 kind:mpr text:error", "started:~3 kind:mpr message:\"error\"")]
         public void TimelineRoundTrip(string toParse, string userQuery)
         {
             var options = new SearchTimelinesRequest();
             options.ParseQueryString(toParse);
             Assert.Equal(userQuery, options.GetQueryString());
         }
-
 
         [Theory]
         [InlineData("text:\"error\"", "started:~7 text:\"error\"")]
@@ -89,13 +91,13 @@ namespace DevOps.Util.UnitTests
         [Fact]
         public void ExplititStartOverridesQuery()
         {
-            var request = new SearchTimelinesRequest("started:~7 text:error")
+            var request = new SearchTimelinesRequest("started:~7 message:error")
             {
                 Started = null,
             };
 
             Assert.Null(request.Started);
-            Assert.Equal(@"text:""error""", request.GetQueryString());
+            Assert.Equal(@"message:""error""", request.GetQueryString());
         }
     }
 }

--- a/DevOps.Util.UnitTests/TrackingGitHubUtilTests.cs
+++ b/DevOps.Util.UnitTests/TrackingGitHubUtilTests.cs
@@ -35,7 +35,7 @@ namespace DevOps.Util.UnitTests
                 title: "Dog Search",
                 timelinesRequest: new SearchTimelinesRequest()
                 {
-                    Text = "dog",
+                    Message = "dog",
                 });
             var match = AddTrackingMatch(tracking, attempt, timelineIssue: timeline);
             var result = AddTrackingResult(tracking, attempt);

--- a/DevOps.Util.UnitTests/TrackingIssueUtilTests.cs
+++ b/DevOps.Util.UnitTests/TrackingIssueUtilTests.cs
@@ -45,7 +45,7 @@ namespace DevOps.Util.UnitTests
             var timeline = AddTimelineIssue("windows|dog", attempt);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" });
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" });
             await Context.SaveChangesAsync();
 
             await TrackingIssueUtil.TriageAsync(attempt);
@@ -68,7 +68,7 @@ namespace DevOps.Util.UnitTests
             var timeline2 = AddTimelineIssue("windows|dog", attempt2);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" },
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" },
                 definition: def2);
             await Context.SaveChangesAsync();
 
@@ -87,7 +87,7 @@ namespace DevOps.Util.UnitTests
             var timeline = AddTimelineIssue("windows|dog", attempt);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" });
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" });
             await Context.SaveChangesAsync();
 
             await TrackingIssueUtil.TriageAsync(attempt);
@@ -131,7 +131,7 @@ namespace DevOps.Util.UnitTests
             var timeline2 = AddTimelineIssue("windows|dog", attempt2);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" },
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" },
                 definition: def2);
             await Context.SaveChangesAsync();
 
@@ -153,7 +153,7 @@ namespace DevOps.Util.UnitTests
             var timeline2 = AddTimelineIssue("windows|dog", attempt2);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" });
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" });
             await Context.SaveChangesAsync();
 
             await TrackingIssueUtil.TriageAsync(attempt1.GetBuildAttemptKey(), tracking.Id);
@@ -177,7 +177,7 @@ namespace DevOps.Util.UnitTests
             var timeline2 = AddTimelineIssue("windows|dog", attempt2);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" });
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" });
             await Context.SaveChangesAsync();
 
             await TrackingIssueUtil.TriageAsync(attempt1.GetBuildAttemptKey(), tracking.Id);
@@ -197,7 +197,7 @@ namespace DevOps.Util.UnitTests
             var timeline2 = AddTimelineIssue("windows|dog", attempt2);
             var tracking = AddTrackingIssue(
                 TrackingKind.Timeline,
-                timelinesRequest: new SearchTimelinesRequest() { Text = "#dog" });
+                timelinesRequest: new SearchTimelinesRequest() { Message = "#dog" });
             await Context.SaveChangesAsync();
 
             await TrackingIssueUtil.TriageAsync(attempt1.GetBuildAttemptKey(), tracking.Id);

--- a/scratch/Program.cs
+++ b/scratch/Program.cs
@@ -58,17 +58,13 @@ namespace Scratch
                 {
                     Console.WriteLine("Using SQL test");
                 } 
-                else if (connectionString.Contains("Catalog=runfo-prod"))
+                else if (connectionString.Contains("Catalog=runfo-prod2"))
                 {
                     Console.WriteLine("Using SQL production");
                 }
-                else if (connectionString.Contains("triage-scratch-dev"))
-                {
-                    Console.WriteLine("Using SQL test (old)");
-                }
                 else
                 {
-                    Console.WriteLine("Using SQL production (old)");
+                    throw new Exception($"Connection string not recognized");
                 }
 
                 builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(145).TotalSeconds).EnableRetryOnFailure());
@@ -125,7 +121,7 @@ namespace Scratch
             builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(5).TotalSeconds));
             //builder.UseSqlServer(connectionString, opts => opts.CommandTimeout((int)TimeSpan.FromMinutes(145).TotalSeconds));
 
-            builder.UseLoggerFactory(LoggerFactory.Create(builder => builder.AddConsole()));
+            // builder.UseLoggerFactory(LoggerFactory.Create(builder => builder.AddConsole()));
             TriageContextOptions = builder.Options;
             TriageContext = new TriageContext(builder.Options);
             TriageContextUtil = new TriageContextUtil(TriageContext);
@@ -169,10 +165,10 @@ namespace Scratch
 
         internal async Task Scratch()
         {
-            await MeasureTrackingIssuePerf();
+            await PopulateDb();
+            // await MeasureTrackingIssuePerf();
 
 
-            // await PopulateDb();
             // await Migrate();
             //await PopulateDb(count: 100, definitionId: 15, includeTests: true, includeTriage: false);
 
@@ -349,7 +345,8 @@ namespace Scratch
 
         internal async Task PopulateDb()
         {
-            const int maxParallel = 4;
+            // At 10 you start getting rate limited1
+            const int maxParallel = 5;
             var logger = CreateLogger();
             var startTime = DateTime.UtcNow;
             var buildCount = 0;


### PR DESCRIPTION
The search for timeline and tests were using different query syntax for
looking for text / messages in the errors. This change normalizes the
syntax so they both accept the same syntax now.