### PR TITLE
Better test result detection

### DIFF
--- a/DevOps.Util.DotNet/HelixUtil.cs
+++ b/DevOps.Util.DotNet/HelixUtil.cs
@@ -113,7 +113,7 @@ namespace DevOps.Util.DotNet
                     }
                 }
 
-                if (file.FileName.StartsWith("testResults", StringComparison.OrdinalIgnoreCase))
+                if (file.FileName.EndsWith(".xml"))
                 {
                     testResultsUri = file.Uri;
                 }


### PR DESCRIPTION
Change the heuristic for test result detection to be just any XML file.
The different repositories use very different names for the result file
schema so easiest to just pick the XML one. Thus far no one is uploading
more than one XML file in test runs.