### PR TITLE
Use real SQL server for testing

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -27,7 +27,18 @@ jobs:
 
     - name: Restore
       run: dotnet restore
+
     - name: Build
       run: dotnet build --configuration Debug --no-restore
+
+    - name: Pull docker image
+      run: docker pull jaredpar/runfo:v0.1.0
+
+    - name: Run docker image
+      run: docker run --rm -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=password@0" -p 1433:1433 --name sql-runfo-test -h sql1 -d jaredpar/runfo:v0.1.0 
+
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+
+    - name: Stop docker image
+      run: docker kill sql-runfo-test

--- a/DevOps.Util.UnitTests/DatabaseFixture.cs
+++ b/DevOps.Util.UnitTests/DatabaseFixture.cs
@@ -1,0 +1,51 @@
+﻿using DevOps.Util.DotNet.Triage;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text;
+using Xunit;
+
+namespace DevOps.Util.UnitTests
+{
+    public class DatabaseFixture : IDisposable
+    {
+        public TriageContext TriageContext { get; private set; }
+
+        public DatabaseFixture()
+        {
+            TriageContext = CreateInMemoryDatabase();
+        }
+
+        private static TriageContext CreateInMemoryDatabase()
+        {
+            var connection = new SqliteConnection("Filename=:memory:");
+            connection.Open();
+            var options = new DbContextOptionsBuilder<TriageContext>()
+                .UseSqlite(connection)
+                .Options;
+            var context = new TriageContext(options);
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        public void Dispose()
+        {
+            TriageContext.Dispose();
+        }
+
+        public void TestCompletion()
+        {
+            TriageContext.Dispose();
+            TriageContext = CreateInMemoryDatabase();
+        }
+    }
+
+    [CollectionDefinition(DatabaseCollection.Name)]
+    public class DatabaseCollection : ICollectionFixture<DatabaseFixture>
+    {
+        public const string Name = "TriageContext Database Collection";
+    }
+}

--- a/DevOps.Util.UnitTests/DatabaseFixture.cs
+++ b/DevOps.Util.UnitTests/DatabaseFixture.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -11,18 +12,27 @@ namespace DevOps.Util.UnitTests
 {
     public class DatabaseFixture : IDisposable
     {
+        public DbContextOptions<TriageContext> Options { get; }
         public TriageContext TriageContext { get; private set; }
 
         public DatabaseFixture()
         {
-            TriageContext = CreateInMemoryDatabase();
+            var builder = new DbContextOptionsBuilder<TriageContext>();
+            builder.UseSqlServer("Server=localhost;Database=runfo-test-db;User Id=sa;Password=password@0;");
+            builder.EnableSensitiveDataLogging();
+            Options = builder.Options;
+            TriageContext = new TriageContext(Options);
+            TriageContext.Database.EnsureDeleted();
+            TriageContext.Database.Migrate();
         }
 
+        /*
         private static TriageContext CreateInMemoryDatabase()
         {
             var connection = new SqliteConnection("Filename=:memory:");
             connection.Open();
             var options = new DbContextOptionsBuilder<TriageContext>()
+                .UseSqlServer()
                 .UseSqlite(connection)
                 .Options;
             var context = new TriageContext(options);
@@ -30,16 +40,30 @@ namespace DevOps.Util.UnitTests
             context.Database.EnsureCreated();
             return context;
         }
+        */
+
+        public void AssertEmpty()
+        {
+            Assert.Equal(0, TriageContext.ModelBuilds.Count());
+            Assert.Equal(0, TriageContext.ModelBuildDefinitions.Count());
+        }
 
         public void Dispose()
         {
+            TriageContext.Database.EnsureDeleted();
             TriageContext.Dispose();
         }
 
         public void TestCompletion()
         {
-            TriageContext.Dispose();
-            TriageContext = CreateInMemoryDatabase();
+            TriageContext.ModelTrackingIssues.RemoveRange(TriageContext.ModelTrackingIssues);
+            TriageContext.ModelTimelineIssues.RemoveRange(TriageContext.ModelTimelineIssues);
+            TriageContext.ModelTestResults.RemoveRange(TriageContext.ModelTestResults);
+            TriageContext.ModelTestRuns.RemoveRange(TriageContext.ModelTestRuns);
+            TriageContext.ModelBuilds.RemoveRange(TriageContext.ModelBuilds);
+            TriageContext.ModelBuildDefinitions.RemoveRange(TriageContext.ModelBuildDefinitions);
+            TriageContext.SaveChanges();
+            AssertEmpty();
         }
     }
 

--- a/DevOps.Util.UnitTests/Extensions.cs
+++ b/DevOps.Util.UnitTests/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -8,5 +9,11 @@ namespace DevOps.Util.UnitTests
     internal static class Extensions
     {
         internal static string TrimNewlines(this string str) => str.Trim('\r', '\n');
+
+        internal static void Clear<T>(this DbSet<T> dbSet)
+            where T : class
+        {
+            dbSet.RemoveRange(dbSet);
+        }
     }
 }

--- a/DevOps.Util.UnitTests/SearchRequestTests.cs
+++ b/DevOps.Util.UnitTests/SearchRequestTests.cs
@@ -9,10 +9,11 @@ using Xunit.Abstractions;
 
 namespace DevOps.Util.UnitTests
 {
+    [Collection(DatabaseCollection.Name)]
     public class SearchRequestTests : StandardTestBase
     {
-        public SearchRequestTests(ITestOutputHelper testOutputHelper)
-            : base(testOutputHelper)
+        public SearchRequestTests(DatabaseFixture databaseFixture, ITestOutputHelper testOutputHelper)
+            : base(databaseFixture, testOutputHelper)
         {
 
         }

--- a/DevOps.Util.UnitTests/StandardTestBase.cs
+++ b/DevOps.Util.UnitTests/StandardTestBase.cs
@@ -38,9 +38,7 @@ namespace DevOps.Util.UnitTests
 
         public StandardTestBase(DatabaseFixture databaseFixture, ITestOutputHelper testOutputHelper)
         {
-            Assert.Equal(0, databaseFixture.TriageContext.ModelBuilds.Count());
-            Assert.Equal(0, databaseFixture.TriageContext.ModelBuildDefinitions.Count());
-
+            databaseFixture.AssertEmpty();
             DatabaseFixture = databaseFixture;
             TriageContextUtil = new TriageContextUtil(Context);
             TestableHttpMessageHandler = new TestableHttpMessageHandler();

--- a/DevOps.Util.UnitTests/TrackingGitHubUtilTests.cs
+++ b/DevOps.Util.UnitTests/TrackingGitHubUtilTests.cs
@@ -14,12 +14,13 @@ using Xunit.Abstractions;
 
 namespace DevOps.Util.UnitTests
 {
+    [Collection(DatabaseCollection.Name)]
     public sealed class TrackingGitHubUtilTests : StandardTestBase
     {
         public TrackingGitHubUtil TrackingGitHubUtil { get; }
 
-        public TrackingGitHubUtilTests(ITestOutputHelper testOutputHelper)
-            : base(testOutputHelper)
+        public TrackingGitHubUtilTests(DatabaseFixture databaseFixture, ITestOutputHelper testOutputHelper)
+            : base(databaseFixture, testOutputHelper)
         {
             TrackingGitHubUtil = new TrackingGitHubUtil(TestableGitHubClientFactory, Context, new SiteLinkUtil("localhost"), TestableLogger);
         }

--- a/DevOps.Util.UnitTests/TrackingGitHubUtilTests.cs
+++ b/DevOps.Util.UnitTests/TrackingGitHubUtilTests.cs
@@ -42,8 +42,8 @@ namespace DevOps.Util.UnitTests
             var result = AddTrackingResult(tracking, attempt);
             await Context.SaveChangesAsync();
 
-            var expected = @"
-Runfo Tracking Issue: [Dog Search](https://localhost/tracking/issue/1)
+            var expected = $@"
+Runfo Tracking Issue: [Dog Search](https://localhost/tracking/issue/{tracking.Id})
 |Definition|Build|Kind|Job Name|
 |---|---|---|---|
 |[roslyn](https://dnceng.visualstudio.com/public/_build?definitionId=42)|[1](https://dev.azure.com/dnceng/public/_build/results?buildId=1)|Rolling|windows|
@@ -83,8 +83,8 @@ Build Result Summary
             await Context.SaveChangesAsync();
             await TriageAll();
 
-            var expected = @"
-Runfo Tracking Issue: [Test Search](https://localhost/tracking/issue/1)
+            var expected = $@"
+Runfo Tracking Issue: [Test Search](https://localhost/tracking/issue/{tracking.Id})
 |Build|Definition|Kind|Run Name|
 |---|---|---|---|
 |[7](https://dev.azure.com/dnceng/public/_build/results?buildId=7)|[roslyn](https://dnceng.visualstudio.com/public/_build?definitionId=42)|Rolling|windows|

--- a/DevOps.Util.UnitTests/TrackingIssueUtilTests.cs
+++ b/DevOps.Util.UnitTests/TrackingIssueUtilTests.cs
@@ -15,12 +15,13 @@ using Xunit.Abstractions;
 
 namespace DevOps.Util.UnitTests
 {
+    [Collection(DatabaseCollection.Name)]
     public sealed class TrackingIssueUtilTests : StandardTestBase
     {
         public TrackingIssueUtil TrackingIssueUtil { get; }
 
-        public TrackingIssueUtilTests(ITestOutputHelper testOutputHelper)
-            : base(testOutputHelper)
+        public TrackingIssueUtilTests(DatabaseFixture databaseFixture, ITestOutputHelper testOutputHelper)
+            : base(databaseFixture, testOutputHelper)
         {
             TrackingIssueUtil = new TrackingIssueUtil(HelixServer, QueryUtil, TriageContextUtil, TestableLogger);
         }

--- a/DevOps.Util.UnitTests/TriageContextUtilTests.cs
+++ b/DevOps.Util.UnitTests/TriageContextUtilTests.cs
@@ -10,10 +10,11 @@ using Xunit.Abstractions;
 
 namespace DevOps.Util.UnitTests
 {
+    [Collection(DatabaseCollection.Name)]
     public class TriageContextUtilTests : StandardTestBase
     {
-        public TriageContextUtilTests(ITestOutputHelper testOutputHelper)
-            : base(testOutputHelper)
+        public TriageContextUtilTests(DatabaseFixture databaseFixture, ITestOutputHelper testOutputHelper)
+            : base(databaseFixture, testOutputHelper)
         {
         }
 

--- a/Misc/Dockerfile
+++ b/Misc/Dockerfile
@@ -1,0 +1,28 @@
+## Source: https://github.com/Microsoft/mssql-docker/blob/master/linux/preview/examples/mssql-agent-fts-ha-tools/Dockerfile
+
+# mssql-agent-fts-ha-tools
+# Maintainers: Microsoft Corporation (twright-msft on GitHub)
+# GitRepo: https://github.com/Microsoft/mssql-docker
+
+# Base OS layer: Latest Ubuntu LTS
+FROM ubuntu:16.04
+
+# Install prerequistes since it is needed to get repo config for SQL server
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -yq curl apt-transport-https && \
+    # Get official Microsoft repository configuration
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list | tee /etc/apt/sources.list.d/mssql-server.list && \
+    apt-get update && \
+    # Install SQL Server from apt
+    apt-get install -y mssql-server && \
+    # Install optional packages
+    apt-get install -y mssql-server-ha && \
+    apt-get install -y mssql-server-fts && \
+    # Cleanup the Dockerfile
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+# Run SQL Server process
+CMD /opt/mssql/bin/sqlservr

--- a/Misc/test-server.ps1
+++ b/Misc/test-server.ps1
@@ -1,0 +1,10 @@
+param ([switch]$start, [switch]$stop)
+
+if ($start) {
+  & docker pull jaredpar/runfo:v0.1.0
+  & docker run --rm -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=password@0" -p 1433:1433 --name sql-runfo-test -h sql1 -d jaredpar/runfo:v0.1.0 
+}
+
+if ($stop) {
+  & docker kill sql-runfo-test
+}


### PR DESCRIPTION
This moves the unit tests from using SQLite for testing to real SQL server. The approach is to run SQL under a docker image and connect to it while the tests are executing. 