### PR TITLE
Add help tooltips to explain the data in the definition build pass table

### DIFF
--- a/DevOps.Status/Pages/View/Definition.cshtml
+++ b/DevOps.Status/Pages/View/Definition.cshtml
@@ -24,10 +24,37 @@
             <thead>
                 <tr>
                     <th scope="col">Days</th>
-                    <th scope="col">Rolling</th>
-                    <th title="Merged Pull Requests" scope="col">Merged PR</th>
-                    <th title="Merged Pull Requests Attempt 1" scope="col">Merged PR Attempt 1</th>
-                    <th scope="col">Total</th>
+                    <th scope="col">
+                        Rolling
+                        <a href="#" data-toggle="tooltip" data-html="true" data-container="body"
+                        title="The pass rate for builds triggered after a commit was checked-in to the main repo. 
+<p>Failures here generally indicate issues in CI as these are supposedly `good` changes.</p>">
+                            &#9432; <!-- ⓘ -->
+                        </a>
+                    </th>
+                    <th scope="col">
+                        Merged PR
+                        <a href="#" data-toggle="tooltip" data-html="true" data-container="body"
+                        title="The pass rate for the final PR build prior to merging the PR. 
+<p>For required checks, this will be 100% (or close to it) as the build must pass to merge the PR.</p>">
+                            &#9432; <!-- ⓘ -->
+                        </a>
+                    </th>
+                    <th title="Merged Pull Requests Attempt 1" scope="col">
+                        Merged PR Attempt 1
+                        <a href="#" data-toggle="tooltip" data-html="true" data-container="body"
+                        title="The pass rate of the <b>first</b> attempt for the final PR build prior to merging the PR.
+<p>For required checks this column may be more useful than the 'Merged PR' column since it shows flakiness in builds that were eventually merged ('good' builds).</p>">
+                            &#9432; <!-- ⓘ -->
+                        </a>
+                    </th>
+                    <th scope="col">
+                        Total
+                        <a href="#" data-toggle="tooltip" 
+                        title="The pass rate for any build triggered by this pipeline - pull request, rolling, or manual.">
+                            &#9432; <!-- ⓘ -->
+                        </a>
+                    </th>
                 </tr>
             </thead>
             <tbody>

--- a/DevOps.Status/wwwroot/css/site.css
+++ b/DevOps.Status/wwwroot/css/site.css
@@ -69,3 +69,8 @@ body {
   white-space: nowrap;
   line-height: 60px; /* Vertically center the text there */
 }
+
+/* Allow tooltips to be wider than the default bootstrap version */
+.tooltip-inner {
+    max-width: 400px;
+}

--- a/DevOps.Status/wwwroot/js/site.js
+++ b/DevOps.Status/wwwroot/js/site.js
@@ -2,3 +2,6 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your Javascript code.
+
+// Enable all tooltips
+$('[data-toggle="tooltip"]').tooltip('enable')


### PR DESCRIPTION
This is just a minor QOL improvement to the definition page since I didn't have time to do anything complicated this week.

When going over the tool in the infra standup, the first question that we all had was "what do these columns mean".  I attempted to resolve this with better help tooltips.  They look something like this:
![help_tooltips](https://user-images.githubusercontent.com/5749229/131201192-20f828f2-a72f-4a9d-931a-776ba9bd0841.png)
I'm using the bootstrap tooltip functionality as it allows them to be clickable + customization to make them look better than the default ones provided just by including a "title" attribute.  They should show up on hover and click, with link colorization on the icon to indicate they are interactable.  

I am very open to criticism on the text in the tooltip - this was the best I could come up with today but I'm not entirely happy with it.  I'm also _not_ a frontend person so happy to hear better ways of doing this.  If there are other locations where you think this kind of help text is valuable, let me know and I can go add it.