### PR TITLE
Set rollForward policy for runfo global too

### DIFF
--- a/runfo/runfo.csproj
+++ b/runfo/runfo.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
 
     <!-- NuGet Information -->
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
This allows runfo to execute on a higher dotnet version if 3.1.0 is not installed