### PR TITLE
Fix variable setting on non-Windows platforms

### DIFF
--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -122,6 +122,7 @@ namespace DevOps.Util
                             $"set {name}={value}" :
                             $"export {name}=\"{value}\"";
                     Console.WriteLine(SetVariable("HELIX_CORRELATION_PAYLOAD", correlationDir));
+                    Console.WriteLine(SetVariable("HELIX_WORKITEM_ROOT", itemDir));
                     Console.WriteLine(SetVariable("HELIX_PYTHONPATH", "echo skipping python"));
                     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {

--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -123,6 +123,10 @@ namespace DevOps.Util
                             $"export {name}=\"{value}\"";
                     Console.WriteLine(SetVariable("HELIX_CORRELATION_PAYLOAD", correlationDir));
                     Console.WriteLine(SetVariable("HELIX_PYTHONPATH", "echo skipping python"));
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        Console.WriteLine($"chmod +x {workItemInfo.Command}");
+                    }
                     Console.WriteLine($"pushd {itemDir} && {workItemInfo.Command} && popd");
                     Console.WriteLine();
 

--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -120,7 +120,7 @@ namespace DevOps.Util
                     string SetVariable(string name, string value) =>
                         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                             $"set {name}={value}" :
-                            $"name=\"{value}\"";
+                            $"export {name}=\"{value}\"";
                     Console.WriteLine(SetVariable("HELIX_CORRELATION_PAYLOAD", correlationDir));
                     Console.WriteLine(SetVariable("HELIX_PYTHONPATH", "echo skipping python"));
                     Console.WriteLine($"pushd {itemDir} && {workItemInfo.Command} && popd");


### PR DESCRIPTION
It wasn't printing the actual variable name and we also need to `export` it, otherwise the variable isn't visible inside the workitem script.

We also need to mark the .sh file as executable and set the `HELIX_WORKITEM_ROOT` env variable.

/cc @ericstj @jaredpar 