### PR TITLE
Make deleting old builds more incremental

### DIFF
--- a/scratch/Program.cs
+++ b/scratch/Program.cs
@@ -167,7 +167,9 @@ namespace Scratch
 
         internal async Task Scratch()
         {
-            await FindMatchingSdkMissingBuilds();
+            Reset(useProduction: true);
+            await DeleteOldBuilds();
+            // await FindMatchingSdkMissingBuilds();
             // await FindLogMacBuildAsync();
         }
         internal async Task FindMatchingSdkMissingBuilds()


### PR DESCRIPTION
Have a situation where deleting old builds is failing because we have
too many test failures. That causes the function to timeout trying to
delete the build. Adjust the function code to start trimming down the
build in this case so that we at least make progress on every invocation
of the function