### PR TITLE
Helix server authentication

### DIFF
--- a/DevOps.Functions/Functions.cs
+++ b/DevOps.Functions/Functions.cs
@@ -139,7 +139,7 @@ namespace DevOps.Functions
 
             var build = await Server.GetBuildAsync(projectName, buildNumber);
             var queryUtil = new DotNetQueryUtil(Server);
-            var modelDataUtil = new ModelDataUtil(queryUtil, TriageContextUtil, logger);
+            var modelDataUtil = new ModelDataUtil(queryUtil, HelixServer, TriageContextUtil, logger);
             var buildAttemptKey = await modelDataUtil.EnsureModelInfoAsync(build);
 
             await triageCollector.AddAsync(JsonConvert.SerializeObject(new BuildMessage(buildAttemptKey.BuildKey)));

--- a/DevOps.Functions/Startup.cs
+++ b/DevOps.Functions/Startup.cs
@@ -35,7 +35,10 @@ namespace DevOps.Functions
                 new DevOpsServer(
                     DotNetConstants.AzureOrganization,
                     new AuthorizationToken(AuthorizationKind.PersonalAccessToken, azdoToken)));
-            builder.Services.AddScoped(_ => new HelixServer(token: helixToken));
+
+            // Using anonymous Helix for now as it has a higher API rate limit than authenticated
+            // https://github.com/dotnet/arcade/issues/10764
+            builder.Services.AddScoped(_ => new HelixServer(token: null));
 
             builder.Services.AddScoped<GitHubClientFactory>(_ =>
             {

--- a/DevOps.Util.DotNet/Triage/ModelDataUtil.cs
+++ b/DevOps.Util.DotNet/Triage/ModelDataUtil.cs
@@ -15,19 +15,20 @@ namespace DevOps.Util.DotNet.Triage
     public sealed class ModelDataUtil
     {
         internal DevOpsServer Server { get; }
-
         internal DotNetQueryUtil QueryUtil { get; }
-
+        internal HelixServer HelixServer { get; }
         internal TriageContextUtil TriageContextUtil { get; }
 
         internal ILogger Logger { get; }
 
         public ModelDataUtil(
             DotNetQueryUtil queryUtil,
+            HelixServer helixServer,
             TriageContextUtil triageContextUtil, 
             ILogger logger)
         {
             Server = queryUtil.Server;
+            HelixServer = helixServer;
             QueryUtil = queryUtil;
             TriageContextUtil = triageContextUtil;
             Logger = logger;
@@ -142,7 +143,7 @@ namespace DevOps.Util.DotNet.Triage
                             dotNetTestRun.TestCaseResults.Take(maxTestCaseResultCount).ToReadOnlyCollection());
                     }
 
-                    var helixApi = HelixServer.GetHelixApi();
+                    var helixApi = HelixServer.HelixApi;
                     var helixMap = await helixApi.GetHelixMapAsync(dotNetTestRun).ConfigureAwait(false);
 
                     await TriageContextUtil.EnsureTestRunAsync(modelBuildAttempt, dotNetTestRun, helixMap).ConfigureAwait(false);

--- a/DevOps.Util.UnitTests/HelixServerTests.cs
+++ b/DevOps.Util.UnitTests/HelixServerTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace DevOps.Util.UnitTests;
+
+public sealed class HelixServerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TokenEmpty(string tokenValue)
+    {
+        var helixServer = new HelixServer(token: tokenValue);
+        Assert.Null(helixServer.Token);
+        Assert.Null(helixServer.HelixApi.Options.Credentials);
+    }
+}

--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -24,12 +24,13 @@ namespace DevOps.Util
         private readonly string? _token;
         private readonly string? _helixBaseUri;
 
+        public string? Token => _token;
         public IHelixApi HelixApi => GetHelixApi(_helixBaseUri, _token);
 
         public HelixServer(string? helixBaseUri = null, string? token = null, HttpClient? httpClient = null)
         {
             _helixBaseUri = helixBaseUri;
-            _token = token;
+            _token = string.IsNullOrEmpty(token) ? null : token;
             _client = new DevOpsHttpClient(httpClient: httpClient);
         }
 

--- a/scratch/MigrateUtil.cs
+++ b/scratch/MigrateUtil.cs
@@ -27,12 +27,13 @@ namespace Scratch
 
         public MigrateUtil(
             DotNetQueryUtil queryUtil,
+            HelixServer helixServer,
             TriageContextUtil triageContextUtil,
             ILogger logger)
         {
             DotNetQueryUtil = queryUtil;
             TriageContextUtil = triageContextUtil;
-            ModelDataUtil = new ModelDataUtil(queryUtil, triageContextUtil, logger);
+            ModelDataUtil = new ModelDataUtil(queryUtil, helixServer, triageContextUtil, logger);
         }
 
         private async Task SaveNewId(ModelMigrationKind kind, int oldId, int? newId)


### PR DESCRIPTION
Had to disable helix authentication because the API rate limitting for authenticated clients is too low. Moved back to anonymous where it is a bit higher

https://github.com/dotnet/arcade/issues/10764