### PR TITLE
Migrate definitions to new org

### DIFF
--- a/DevOps.Status/Pages/Tracking/New.cshtml
+++ b/DevOps.Status/Pages/Tracking/New.cshtml
@@ -11,6 +11,11 @@
     </div>
 
     <div class="form-group row">
+        <label class="col-sm-2 col-form-label">Azure Organization</label>
+        <input class="col-sm-10 form-control" type="text" asp-for="AzureOrganization" />
+    </div>
+
+    <div class="form-group row">
         <label class="col-sm-2 col-form-label">Definition</label>
         <input class="col-sm-10 form-control" type="text" asp-for="DefinitionData" />
     </div>

--- a/DevOps.Status/Pages/Tracking/New.cshtml.cs
+++ b/DevOps.Status/Pages/Tracking/New.cshtml.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Octokit;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -45,6 +46,8 @@ namespace DevOps.Status.Pages.Tracking
         public string? GitHubRepository { get; set; }
         [BindProperty]
         public string? GitHubIssueUri { get; set; }
+        [BindProperty]
+        public string? AzureOrganization { get; set; } = DotNetConstants.AzureOrganization;
 
         public string? ErrorMessage { get; set; }
 
@@ -102,10 +105,16 @@ namespace DevOps.Status.Pages.Tracking
                 return Page();
             }
 
+            if (string.IsNullOrEmpty(AzureOrganization))
+            {
+                ErrorMessage = "Must provide an Azure Organization";
+                return Page();
+            }
+
             ModelBuildDefinition? modelBuildDefinition = null;
             if (!string.IsNullOrEmpty(DefinitionData))
             {
-                modelBuildDefinition = await TriageContextUtil.FindModelBuildDefinitionAsync(DefinitionData);
+                modelBuildDefinition = await TriageContextUtil.FindModelBuildDefinitionAsync(AzureOrganization, DefinitionData);
                 if (modelBuildDefinition is null)
                 {
                     ErrorMessage = $"Cannot find build definition with name or ID: {DefinitionData}";

--- a/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
+++ b/DevOps.Util.DotNet/Triage/TriageContextUtil.cs
@@ -358,21 +358,21 @@ namespace DevOps.Util.DotNet.Triage
         public Task<ModelBuildDefinition> GetModelBuildDefinitionAsync(int id) =>
             GetModelBuildDefinitionQueryAsync(id).SingleOrDefaultAsync();
 
-        public async Task<ModelBuildDefinition?> FindModelBuildDefinitionAsync(string nameOrId)
+        public async Task<ModelBuildDefinition?> FindModelBuildDefinitionAsync(string azureOrganization, string nameOrId)
         {
             if (int.TryParse(nameOrId, out var id))
             {
                 return await Context
                     .ModelBuildDefinitions
-                    .Where(x => x.DefinitionNumber == id)
-                    .FirstOrDefaultAsync()
+                    .Where(x => x.DefinitionNumber == id && x.AzureOrganization == azureOrganization)
+                    .SingleOrDefaultAsync()
                     .ConfigureAwait(false);
             }
 
             return await Context
                 .ModelBuildDefinitions
-                .Where(x => x.DefinitionName == nameOrId)
-                .FirstOrDefaultAsync()
+                .Where(x => x.DefinitionName == nameOrId && x.AzureOrganization == azureOrganization)
+                .SingleOrDefaultAsync()
                 .ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Most of our tracking issues were still using the `ModelBuildDefinition` for dnceng and not dnceng-public. They were not fixed up when the migration happened. Locally I reset all active issues to point to the new definition in dnceng-public.

This also fixes a bug where we were still defaulting to dnceng for new tracking issues.