### PR TITLE
Work around Helix truncation issue

### DIFF
--- a/DevOps.Util.DotNet/HelixUtil.cs
+++ b/DevOps.Util.DotNet/HelixUtil.cs
@@ -95,7 +95,7 @@ namespace DevOps.Util.DotNet
             IHelixApi helixApi,
             HelixInfoWorkItem helixWorkItem)
         {
-            var details = await helixApi.WorkItem.DetailsAsync(id: helixWorkItem.WorkItemName, job: helixWorkItem.JobId).ConfigureAwait(false);
+            var details = await helixApi.WorkItem.DetailsExAsync(id: helixWorkItem.WorkItemName, job: helixWorkItem.JobId).ConfigureAwait(false);
             var runClientUri = details.Logs.FirstOrDefault(x => x.Module.StartsWith("run_client"))?.Uri;
             string? dumpUri = null;
             string? testResultsUri = null;

--- a/DevOps.Util.DotNet/Triage/ModelDataUtil.cs
+++ b/DevOps.Util.DotNet/Triage/ModelDataUtil.cs
@@ -34,6 +34,12 @@ namespace DevOps.Util.DotNet.Triage
             Logger = logger;
         }
 
+        public async Task<BuildAttemptKey> EnsureModelInfoAsync(string project, int buildNumber, bool includeTests = true, bool includeAllAttempts = false)
+        {
+            var build = await Server.GetBuildAsync(project, buildNumber).ConfigureAwait(false);
+            return await EnsureModelInfoAsync(build, includeTests, includeAllAttempts).ConfigureAwait(false);
+        }
+
         public async Task<BuildAttemptKey> EnsureModelInfoAsync(Build build, bool includeTests = true, bool includeAllAttempts = false)
         {
             var buildInfo = build.GetBuildResultInfo();

--- a/DevOps.Util/Extensions.cs
+++ b/DevOps.Util/Extensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.DotNet.Helix.Client;
+using Microsoft.DotNet.Helix.Client.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -7,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DevOps.Util
@@ -358,5 +361,25 @@ namespace DevOps.Util
         }
 
         #endregion
+
+        #region IWorkItem
+
+        /// <summary>
+        /// Work around the fact that Helix truncates work item names
+        /// 
+        /// https://github.com/dotnet/arcade/issues/11079
+        /// </summary>
+        public static Task<WorkItemDetails> DetailsExAsync(this IWorkItem @this, string id, string job, CancellationToken cancellationToken = default)
+        {
+            if (id.Length > 200)
+            {
+                id = id.Substring(0, 197);
+                id = id + "...";
+            }
+            return @this.DetailsAsync(id: id, job: job, cancellationToken);
+        }
+
+        #endregion
+
     }
 }

--- a/scratch/Program.cs
+++ b/scratch/Program.cs
@@ -172,7 +172,9 @@ namespace Scratch
 
         internal async Task Scratch()
         {
-            await FixTrackingIssuesAsync();
+            Reset(useProduction: true);
+            var util = new ModelDataUtil(DotNetQueryUtil, HelixServer, TriageContextUtil, CreateLogger());
+            await util.EnsureModelInfoAsync("public", 35950, includeTests: true);
         }
 
         /// <summary>


### PR DESCRIPTION
Helix has a limit of 200 characters on work item friendly names. Anything exceeding that will be silently truncated on upload. The query APIs do not do a similar truncation hence we must do it manually.

https://github.com/dotnet/arcade/issues/11079