### PR TITLE
Fix Microsoft.Extensions.Configuration deployment error

### DIFF
--- a/DevOps.Functions/DevOps.Functions.csproj
+++ b/DevOps.Functions/DevOps.Functions.csproj
@@ -8,8 +8,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DevOps.Util.DotNet\DevOps.Util.DotNet.csproj" />

--- a/DevOps.Functions/local.settings.json
+++ b/DevOps.Functions/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "AzureWebJobsDashboard": "UseDevelopmentStorage=true"
+  }
+}


### PR DESCRIPTION
The function app was failing with the error

> Could not load file or assembly 'Microsoft.Extensions.Configuration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'

This is true even though that DLL at that version was deployed with the function. The reason is that the function runtime is on .NET 6.0 and it loads several dependencies before it loads the function code. Anything loaded by the function runtime can't be overridden by the function app. In this case MS.E.Configuration was one of those extensions. More simply it was a mistake to use 7.0.0 here on a .NET 6 runtime, should've kept it at 6.0.1 from the start.