### PR TITLE
Fix extra space after HELIX_WORKITEM_ID and HELIX_CURRENT_LOG variables

### DIFF
--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -131,7 +131,7 @@ namespace DevOps.Util
                     Console.WriteLine(SetVariable("HELIX_WORKITEM_ROOT", itemDir));
                     Console.WriteLine(SetVariable("HELIX_WORKITEM_UPLOAD_ROOT", itemDir));
                     Console.WriteLine(SetVariable("HELIX_DUMP_FOLDER", itemDir));
-                    Console.WriteLine(SetVariable("HELIX_CURRENT_LOG ", Path.Combine(itemDir, "log.txt")));
+                    Console.WriteLine(SetVariable("HELIX_CURRENT_LOG", Path.Combine(itemDir, "log.txt")));
                     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
                         Console.WriteLine($"chmod +x {workItemInfo.Command}");

--- a/DevOps.Util/HelixServer.cs
+++ b/DevOps.Util/HelixServer.cs
@@ -126,7 +126,7 @@ namespace DevOps.Util
                     Console.WriteLine(SetVariable("HELIX_CORRELATION_PAYLOAD", correlationDir));
                     Console.WriteLine(SetVariable("HELIX_PYTHONPATH", "echo skipping python"));
                     Console.WriteLine(SetVariable("HELIX_WORKITEM_FRIENDLYNAME", workItemInfo.WorkItemId!));
-                    Console.WriteLine(SetVariable("HELIX_WORKITEM_ID ", workItemInfo.WorkItemId!));
+                    Console.WriteLine(SetVariable("HELIX_WORKITEM_ID", workItemInfo.WorkItemId!));
                     Console.WriteLine(SetVariable("HELIX_WORKITEM_PAYLOAD", itemDir));
                     Console.WriteLine(SetVariable("HELIX_WORKITEM_ROOT", itemDir));
                     Console.WriteLine(SetVariable("HELIX_WORKITEM_UPLOAD_ROOT", itemDir));


### PR DESCRIPTION
This causes an error when copy-pasted into the shell otherwise.

/cc @jaredpar 