### PR TITLE
Add option to create a VS test playlist

### DIFF
--- a/runfo/Program.cs
+++ b/runfo/Program.cs
@@ -132,7 +132,7 @@ namespace Runfo
                 Console.WriteLine("  search-timeline    Search timeline info");
                 Console.WriteLine("  search-helix       Search helix logs");
                 Console.WriteLine("  search-buildlog    Search build logs");
-                Console.WriteLine("  tests              Print build test failures");
+                Console.WriteLine("  search-tests       Print build test failures");
                 Console.WriteLine("  timeline           Dump the timeline");
                 Console.WriteLine("  yaml               Dump the YML for a build");
                 Console.WriteLine();


### PR DESCRIPTION
Running e.g.

```ps1
.\runfo\bin\Debug\net7.0\runfo.exe pr-builds -r dotnet/roslyn -n 71911
.\runfo\bin\Debug\net7.0\runfo.exe search-tests -b 549305 --playlist runfo.playlist
```

Creates `runfo.playlist` that can be opened via VS Test Explorer so one can then run all failed tests from the given PR.

I would like to add similar functionality (to download the playlist file) to the web UI, but I'm not sure how to run the web project locally. (I just saw https://github.com/jaredpar/runfo/pull/170, that might help, will try that later.)